### PR TITLE
Added to auth command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 .PHONY: generate
 generate: ## Generates the openhue.gen.go client from the latest https://github.com/openhue/openhue-api specification
 	@$(GO) generate
-	@echo "${GREEN}${BOLD}./openhue/openhue.gen.go successfully generated 🚀${RESET}"
+	@echo "\n${GREEN}${BOLD}./openhue/openhue.gen.go successfully generated 🚀${RESET}"
 
 .PHONY: build
 build: ## Generates the openhue-cli executables in the ./dist folder
@@ -26,10 +26,10 @@ build: ## Generates the openhue-cli executables in the ./dist folder
 .PHONY: tidy
 tidy: ## Tidy makes sure go.mod matches the source code in the module
 	@$(GO) mod tidy
-	@echo "${GREEN}${BOLD}go.mod successfully cleaned 🧽${RESET}"
+	@echo "\n${GREEN}${BOLD}go.mod successfully cleaned 🧽${RESET}"
 
 .PHONY: clean
 clean: ##
 	@rm -rf ./dist
 	@$(GO) clean
-	@echo "${GREEN}${BOLD}Project successfully cleaned 🧹${RESET} (removed ./bin folder + go clean)"
+	@echo "\n${GREEN}${BOLD}Project successfully cleaned 🧹${RESET} (removed ./dist folder + go clean)"

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"openhue-cli/openhue"
+)
+
+var (
+	deviceType        string
+	generateClientKey bool
+)
+
+// authCmd represents the auth command
+var authCmd = &cobra.Command{
+	Use:     "auth",
+	GroupID: "init",
+	Short:   "Authenticate",
+	Long:    `Authenticate to retrieve the HUE application key. Requires to go and press the button on the bridge`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		body := new(openhue.AuthenticateJSONRequestBody)
+		body.Devicetype = &deviceType
+		body.Generateclientkey = &generateClientKey
+		resp, err := openhue.Api.AuthenticateWithResponse(context.Background(), *body)
+		cobra.CheckErr(err)
+
+		auth := (*resp.JSON200).Success
+		fmt.Println(auth.Clientkey)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+
+	authCmd.Flags().StringVarP(&deviceType, "devicetype", "d", "", "Device identifier (example 'app_name#instance_name')")
+	authCmd.MarkFlagRequired("devicetype")
+
+	authCmd.Flags().BoolVarP(&generateClientKey, "generateclientkey", "k", true, "")
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
+	"os"
 )
 
 var (
+	bridge            string
 	deviceType        string
 	generateClientKey bool
 )
@@ -17,25 +19,35 @@ var authCmd = &cobra.Command{
 	Use:     "auth",
 	GroupID: "init",
 	Short:   "Authenticate",
-	Long:    `Authenticate to retrieve the HUE application key. Requires to go and press the button on the bridge`,
+	Long:    `Authenticate to retrieve the Hue Application Key. Requires to go and press the button on the bridge`,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		client := openhue.NewOpenHueClientNoAuth(bridge)
 
 		body := new(openhue.AuthenticateJSONRequestBody)
 		body.Devicetype = &deviceType
 		body.Generateclientkey = &generateClientKey
-		resp, err := openhue.Api.AuthenticateWithResponse(context.Background(), *body)
+		resp, err := client.AuthenticateWithResponse(context.Background(), *body)
 		cobra.CheckErr(err)
 
-		auth := (*resp.JSON200).Success
-		fmt.Println(auth.Clientkey)
+		auth := (*resp.JSON200)[0]
+		if auth.Error != nil {
+			fmt.Println("\n🖲️", *auth.Error.Description)
+		} else {
+			fmt.Println("\nYour hue-application-key ->", *auth.Success.Username)
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(authCmd)
 
-	authCmd.Flags().StringVarP(&deviceType, "devicetype", "d", "", "Device identifier (example 'app_name#instance_name')")
-	authCmd.MarkFlagRequired("devicetype")
+	authCmd.Flags().StringVarP(&bridge, "bridge", "b", "", "Bridge IP (example '192.168.1.23')")
+	authCmd.MarkFlagRequired("bridge")
 
-	authCmd.Flags().BoolVarP(&generateClientKey, "generateclientkey", "k", true, "")
+	hostname, err := os.Hostname()
+	cobra.CheckErr(err)
+	authCmd.Flags().StringVarP(&deviceType, "devicetype", "d", hostname, "Device identifier")
+
+	authCmd.Flags().BoolVarP(&generateClientKey, "generateclientkey", "k", true, "Generate the client key")
 }

--- a/openhue/config.go
+++ b/openhue/config.go
@@ -38,7 +38,7 @@ func Load() *Config {
 	viper.SetConfigType("yaml")
 
 	// List of commands that does not require configuration
-	ignoredCmds := []string{"setup", "help", "discover"}
+	ignoredCmds := []string{"setup", "help", "discover", "auth"}
 
 	// When trying to run CLI without configuration
 	if err := viper.ReadInConfig(); err != nil && !slices.Contains(ignoredCmds, os.Args[1]) {
@@ -62,6 +62,19 @@ func NewOpenHueClient(c *Config) *ClientWithResponses {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	client, err := NewClientWithResponses("https://"+c.ip, WithRequestEditorFn(p.Intercept))
+	cobra.CheckErr(err)
+
+	return client
+}
+
+// NewOpenHueClientNoAuth Creates a new NewClientWithResponses for a given server and no application key.
+// This function will also skip SSL verification, as the Philips HUE Bridge exposes a self-signed certificate.
+func NewOpenHueClientNoAuth(ip string) *ClientWithResponses {
+
+	// skip SSL Verification
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	client, err := NewClientWithResponses("https://" + ip)
 	cobra.CheckErr(err)
 
 	return client

--- a/openhue/openhue.gen.go
+++ b/openhue/openhue.gen.go
@@ -849,7 +849,7 @@ type LightGet struct {
 		// Effect Current status values the light is in regarding timed effects
 		Effect *SupportedTimedEffects `json:"effect,omitempty"`
 
-		// EffectValues Possible timed effect values you can set in a light.
+		// EffectValues Possible timed effect values you can set in a light
 		EffectValues *[]SupportedTimedEffects `json:"effect_values,omitempty"`
 
 		// Status Current status values the light is in regarding timed effects
@@ -1364,7 +1364,12 @@ type TemperaturePut struct {
 type TemperaturePutType string
 
 // Response defines model for response.
-type Response struct {
+type Response = []struct {
+	Error *struct {
+		Address     *string `json:"address,omitempty"`
+		Description *string `json:"description,omitempty"`
+		Type        *int    `json:"type,omitempty"`
+	} `json:"error,omitempty"`
 	Success *struct {
 		Clientkey *string `json:"clientkey,omitempty"`
 		Username  *string `json:"username,omitempty"`


### PR DESCRIPTION
The `openhue auth` command is used to retrieve the `hue-application-key`. 

```
🕙 22:32:07 ❯ go run . auth -h

Authenticate to retrieve the Hue Application Key. Requires to go and press the button on the bridge

Usage:
  openhue-cli auth [flags]

Flags:
  -b, --bridge string       Bridge IP (example '192.168.1.23')
  -d, --devicetype string   Device identifier (default "tpensec-mbp")
  -k, --generateclientkey   Generate the client key (default true)
  -h, --help                help for auth

```