### PR TITLE
Move local config folder to ~/.openhue

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,3 @@
-# The lines bellow are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
-
 project_name: openhue
 
 before:
@@ -29,7 +24,8 @@ builds:
 dockers:
   - id: openhue
     image_templates:
-      - openhue/cli
+      - openhue/cli:latest
+      - openhue/cli:{{ .Tag }}
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -10,24 +10,25 @@ var setupCmd = &cobra.Command{
 	Use:     "setup",
 	GroupID: "init",
 	Short:   "Configure your local Philips HUE environment",
-	Long: `The setup command must be run as a prerequisite. It allows to store your Philips HUE Bridge IP and 
-application key in the configuration file`,
+	Long: `The setup command must be run as a prerequisite for all resource related commands (controlling lights, rooms, scenes, etc.)
+
+It allows to store your Philips Hue Bridge IP and application key in the configuration file (~/.openhue/config.yaml).`,
 	Run: Setup,
 }
 
 func Setup(cmd *cobra.Command, args []string) {
-	err := viper.SafeWriteConfig()
+	err := viper.WriteConfig()
 	cobra.CheckErr(err)
 }
 
 func init() {
 	rootCmd.AddCommand(setupCmd)
 
-	setupCmd.PersistentFlags().StringP("ip", "i", "192.168.1.68", "The local IP of your Philips HUE Bridge")
-	_ = setupCmd.MarkPersistentFlagRequired("ip")
-	_ = viper.BindPFlag("ip", setupCmd.PersistentFlags().Lookup("ip"))
+	setupCmd.Flags().StringP("bridge", "b", "", "The local IP of your Philips Hue Bridge (example '192.168.1.68')")
+	_ = setupCmd.MarkFlagRequired("ip")
+	_ = viper.BindPFlag("ip", setupCmd.Flags().Lookup("ip"))
 
-	setupCmd.PersistentFlags().StringP("key", "k", "####", "Your HUE application key")
-	_ = setupCmd.MarkPersistentFlagRequired("key")
-	_ = viper.BindPFlag("key", setupCmd.PersistentFlags().Lookup("key"))
+	setupCmd.Flags().StringP("key", "k", "", "Your Hue Application Key")
+	_ = setupCmd.MarkFlagRequired("key")
+	_ = viper.BindPFlag("key", setupCmd.Flags().Lookup("key"))
 }

--- a/openhue/config.go
+++ b/openhue/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 )
 
@@ -32,9 +33,12 @@ func Load() *Config {
 	home, err := os.UserHomeDir()
 	cobra.CheckErr(err)
 
+	var configPath = filepath.Join(home, "/.openhue")
+	_ = os.MkdirAll(configPath, os.ModePerm)
+
 	// Search config in home directory with name ".openhue" (without an extension).
-	viper.AddConfigPath(home)
-	viper.SetConfigName(".openhue")
+	viper.AddConfigPath(configPath)
+	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 
 	// List of commands that does not require configuration


### PR DESCRIPTION
For a more future proof configuration management, it appears that it'd be safer to put the local CLI config in a dedicated folder located in the user home directory (e.g. `~`)