### PR TITLE
Fixed config setup when file already exists

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,8 +30,10 @@ dockers:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.description={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.url=https://github.com/openhue/openhue-cli"
 
 brews:
   - name: openhue-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-ENTRYPOINT ["/openhue"]
 COPY openhue /
+ENTRYPOINT ["/openhue"]

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -17,16 +17,19 @@ It allows to store your Philips Hue Bridge IP and application key in the configu
 }
 
 func Setup(cmd *cobra.Command, args []string) {
-	err := viper.WriteConfig()
-	cobra.CheckErr(err)
+	err := viper.SafeWriteConfig()
+	if err != nil {
+		err := viper.WriteConfig()
+		cobra.CheckErr(err)
+	}
 }
 
 func init() {
 	rootCmd.AddCommand(setupCmd)
 
 	setupCmd.Flags().StringP("bridge", "b", "", "The local IP of your Philips Hue Bridge (example '192.168.1.68')")
-	_ = setupCmd.MarkFlagRequired("ip")
-	_ = viper.BindPFlag("ip", setupCmd.Flags().Lookup("ip"))
+	_ = setupCmd.MarkFlagRequired("bridge")
+	_ = viper.BindPFlag("bridge", setupCmd.Flags().Lookup("bridge"))
 
 	setupCmd.Flags().StringP("key", "k", "", "Your Hue Application Key")
 	_ = setupCmd.MarkFlagRequired("key")

--- a/openhue/config.go
+++ b/openhue/config.go
@@ -16,7 +16,7 @@ var Api *ClientWithResponses
 
 type Config struct {
 	// The IP of the Philips HUE bridge
-	ip string
+	bridge string
 	// The HUE Application Key
 	key string
 }
@@ -50,7 +50,7 @@ func Load() *Config {
 		os.Exit(0)
 	}
 
-	c.ip = viper.GetString("ip")
+	c.bridge = viper.GetString("bridge")
 	c.key = viper.GetString("key")
 
 	return c
@@ -65,7 +65,7 @@ func NewOpenHueClient(c *Config) *ClientWithResponses {
 	// skip SSL Verification
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	client, err := NewClientWithResponses("https://"+c.ip, WithRequestEditorFn(p.Intercept))
+	client, err := NewClientWithResponses("https://"+c.bridge, WithRequestEditorFn(p.Intercept))
 	cobra.CheckErr(err)
 
 	return client


### PR DESCRIPTION
There was an issue when attempting to update the config (`openhue setup` command) and the config file already exists in the config path.

I also took the opportunity to rename the `--ip` flag to `--bridge` to improve consistency.