### PR TITLE
Added the set light command

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// setCmd represents the set command
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set resources",
+	Long: `
+Set the values for a specific resource
+`,
+}
+
+func init() {
+	rootCmd.AddCommand(setCmd)
+}

--- a/cmd/set_light.go
+++ b/cmd/set_light.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"openhue-cli/openhue"
 )
 
 var (
-	OnOff bool
+	On  bool
+	Off bool
 )
 
 // setLightCmd represents the setLight command
@@ -23,6 +23,16 @@ Update one or multiple lights (max is 10 lights simultaneously). Allows to turn 
 
 		request := &openhue.UpdateLightJSONRequestBody{}
 
+		OnOff := true
+
+		if On {
+			OnOff = true
+		}
+
+		if Off {
+			OnOff = false
+		}
+
 		request.On = &openhue.On{
 			On: &OnOff,
 		}
@@ -30,9 +40,7 @@ Update one or multiple lights (max is 10 lights simultaneously). Allows to turn 
 		for _, id := range args {
 			_, err := openhue.Api.UpdateLight(context.Background(), id, *request)
 			cobra.CheckErr(err)
-			fmt.Println("Light", id, "successfully updated")
 		}
-
 	},
 }
 
@@ -40,5 +48,7 @@ func init() {
 	setCmd.AddCommand(setLightCmd)
 
 	// local flags
-	setLightCmd.Flags().BoolVar(&OnOff, "on", true, "Turn on or off the lights")
+	setLightCmd.Flags().BoolVar(&On, "on", false, "Turn on the lights")
+	setLightCmd.Flags().BoolVar(&Off, "off", false, "Turn off the lights")
+	setLightCmd.MarkFlagsMutuallyExclusive("on", "off")
 }

--- a/cmd/set_light.go
+++ b/cmd/set_light.go
@@ -13,7 +13,7 @@ var (
 
 // setLightCmd represents the setLight command
 var setLightCmd = &cobra.Command{
-	Use:   "light",
+	Use:   "light [lightId]",
 	Short: "Update one or multiple lights",
 	Long: `
 Update one or multiple lights (max is 10 lights simultaneously). Allows to turn on or off a light.

--- a/cmd/set_light.go
+++ b/cmd/set_light.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+	"openhue-cli/openhue"
+)
+
+var (
+	OnOff bool
+)
+
+// setLightCmd represents the setLight command
+var setLightCmd = &cobra.Command{
+	Use:   "light",
+	Short: "Update one or multiple lights",
+	Long: `
+Update one or multiple lights (max is 10 lights simultaneously). Allows to turn on or off a light.
+`,
+	Args: cobra.MatchAll(cobra.RangeArgs(1, 10), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		request := &openhue.UpdateLightJSONRequestBody{}
+
+		request.On = &openhue.On{
+			On: &OnOff,
+		}
+
+		for _, id := range args {
+			_, err := openhue.Api.UpdateLight(context.Background(), id, *request)
+			cobra.CheckErr(err)
+			fmt.Println("Light", id, "successfully updated")
+		}
+
+	},
+}
+
+func init() {
+	setCmd.AddCommand(setLightCmd)
+
+	// local flags
+	setLightCmd.Flags().BoolVar(&OnOff, "on", true, "Turn on or off the lights")
+}


### PR DESCRIPTION
Added the `openhue set light [lightId]` command.

#### Usage
Set a light on: 
```shell
openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on
```
Set a multiple lights on: 
```shell
openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e 50a903f0-f060-4219-8301-1b56cba41cd0 --on
```
Set a light off: 
```shell
openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --off
```