### PR TITLE
The 'openhue set light' command now allows setting the color

### DIFF
--- a/cmd/set/set_light.go
+++ b/cmd/set/set_light.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"openhue-cli/openhue"
+	"openhue-cli/util/color"
 )
 
 const (
@@ -28,18 +29,39 @@ openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --off
 
 # Set brightness of a single light
 openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65
+
+# Set color (in RGB) of a single light
+openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --rgb #3399FF
+
+# Set color (in CIE space) of a single light
+openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on -x 0.675 -y 0.322
+
+# Set color (by name) of a single light
+openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue
 `
 )
 
 type LightOptions struct {
 	Status     LightStatus
 	Brightness float32
+	Color      color.XY
+}
+
+type LightFlags struct {
+	On         bool
+	Off        bool
+	Brightness float32
+	Rgb        string
+	X          float32
+	Y          float32
+	ColorName  string
 }
 
 func NewSetLightOptions() *LightOptions {
 	return &LightOptions{
 		Status:     Undefined,
 		Brightness: -1,
+		Color:      color.UndefinedColor,
 	}
 }
 
@@ -47,6 +69,7 @@ func NewSetLightOptions() *LightOptions {
 func NewCmdSetLight(api *openhue.ClientWithResponses) *cobra.Command {
 
 	o := NewSetLightOptions()
+	f := LightFlags{}
 
 	cmd := &cobra.Command{
 		Use:     "light [lightId]",
@@ -55,39 +78,90 @@ func NewCmdSetLight(api *openhue.ClientWithResponses) *cobra.Command {
 		Example: docExample,
 		Args:    cobra.MatchAll(cobra.RangeArgs(1, 10), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
-			cobra.CheckErr(o.PrepareCmdSetLight(cmd))
+			cobra.CheckErr(o.PrepareCmdSetLight(&f))
 			cobra.CheckErr(o.RunCmdSetLight(api, args))
 		},
 	}
 
-	// on/off flags
-	cmd.Flags().Bool("on", false, "Turn on the lights")
-	cmd.Flags().Bool("off", false, "Turn off the lights")
-	cmd.MarkFlagsMutuallyExclusive("on", "off")
-
-	// Brightness flag
-	cmd.Flags().Float32VarP(&o.Brightness, "brightness", "b", -1, "Set the brightness [min=0, max=100]")
+	f.InitFlags(cmd)
 
 	return cmd
 }
 
+func (f *LightFlags) InitFlags(cmd *cobra.Command) {
+	// on/off flags
+	cmd.Flags().BoolVar(&f.On, "on", false, "Turn on the lights")
+	cmd.Flags().BoolVar(&f.Off, "off", false, "Turn off the lights")
+	cmd.MarkFlagsMutuallyExclusive("on", "off")
+
+	// Brightness flag
+	cmd.Flags().Float32VarP(&f.Brightness, "brightness", "b", -1, "Set the brightness [min=0, max=100]")
+
+	//
+	// Color flags
+	//
+
+	// rgb
+	cmd.Flags().StringVar(&f.Rgb, "rgb", "", "RGB hexadecimal value (example #CCE5FF)")
+
+	// xy
+	cmd.Flags().Float32VarP(&f.X, "cie-x", "x", -1, "X coordinate in the CIE color space (example 0.675)")
+	cmd.Flags().Float32VarP(&f.Y, "cie-y", "y", -1, "Y coordinate in the CIE color space (example 0.322)")
+	cmd.MarkFlagsRequiredTogether("cie-x", "cie-y")
+
+	// name
+	cmd.Flags().StringVarP(&f.ColorName, "color", "c", "", "Color name. Allowed: white, lime, green, blue, etc.")
+	_ = cmd.RegisterFlagCompletionFunc("color", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return color.GetSupportColorList(), cobra.ShellCompDirectiveDefault
+	})
+
+	// exclusions
+	cmd.MarkFlagsMutuallyExclusive("color", "rgb", "cie-x")
+}
+
 // PrepareCmdSetLight makes sure provided values for LightOptions are valid
-func (o *LightOptions) PrepareCmdSetLight(cmd *cobra.Command) error {
+func (o *LightOptions) PrepareCmdSetLight(flags *LightFlags) error {
 
-	on, _ := cmd.Flags().GetBool("on")
-	off, _ := cmd.Flags().GetBool("off")
-
-	if on {
+	if flags.On {
 		o.Status = On
 	}
 
-	if off {
+	if flags.Off {
 		o.Status = Off
 	}
 
 	// validate the --brightness flag
-	if o.Brightness > 100.0 || (o.Brightness != -1 && o.Brightness < 0) {
+	if flags.Brightness > 100.0 || (flags.Brightness != -1 && flags.Brightness < 0) {
 		return fmt.Errorf("--brightness flag must be greater than 0.0 and lower than 100.0, current value is %.2f", o.Brightness)
+	} else {
+		o.Brightness = flags.Brightness
+	}
+
+	// color in RGB
+	if flags.Rgb != "" {
+		rgb, err := color.NewRGBFomHex(flags.Rgb)
+		if err != nil {
+			return err
+		}
+		o.Color = *rgb.ToXY()
+	}
+
+	// color in CIE space
+	if flags.X >= 0 && flags.Y >= 0 {
+		o.Color = color.XY{
+			X: flags.X,
+			Y: flags.Y,
+		}
+	}
+
+	// color from enum
+	if flags.ColorName != "" {
+		c, err := color.FindColorByName(flags.ColorName)
+		cobra.CheckErr(err)
+		o.Color = color.XY{
+			X: c.X,
+			Y: c.Y,
+		}
 	}
 
 	return nil
@@ -110,8 +184,17 @@ func (o *LightOptions) RunCmdSetLight(api *openhue.ClientWithResponses, args []s
 		}
 	}
 
-	for _, id := range args {
-		_, err := api.UpdateLight(context.Background(), id, *request)
+	if o.Color != color.UndefinedColor {
+		request.Color = &openhue.Color{
+			Xy: &openhue.GamutPosition{
+				X: &o.Color.X,
+				Y: &o.Color.Y,
+			},
+		}
+	}
+
+	for _, lightId := range args {
+		_, err := api.UpdateLight(context.Background(), lightId, *request)
 		cobra.CheckErr(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-//go:generate oapi-codegen --package=openhue -generate=client,types -o ./openhue/openhue.gen.go https://api.redocly.com/registry/bundle/openhue/openhue/v2/openapi.yaml?branch=main
+//go:generate oapi-codegen --package=openhue -generate=client,types -o ./openhue/openhue.gen.go /Users/thibault.pensec/local/perso/openhue-api/build/openhue.yaml
 
 import (
 	"openhue-cli/cmd"

--- a/openhue/openhue.gen.go
+++ b/openhue/openhue.gen.go
@@ -619,6 +619,12 @@ type ColorPaletteGet struct {
 	Dimming *Dimming `json:"dimming,omitempty"`
 }
 
+// ColorTemperature defines model for ColorTemperature.
+type ColorTemperature struct {
+	// Mirek color temperature in mirek or null when the light color is not in the ct spectrum
+	Mirek *Mirek `json:"mirek,omitempty"`
+}
+
 // ColorTemperaturePaletteGet defines model for ColorTemperaturePaletteGet.
 type ColorTemperaturePaletteGet struct {
 	ColorTemperature *struct {
@@ -1114,13 +1120,8 @@ type LightPut struct {
 	Alert *struct {
 		Action *string `json:"action,omitempty"`
 	} `json:"alert,omitempty"`
-
-	// Color CIE XY gamut position
-	Color            *GamutPosition `json:"color,omitempty"`
-	ColorTemperature *struct {
-		// Mirek color temperature in mirek or null when the light color is not in the ct spectrum
-		Mirek *Mirek `json:"mirek,omitempty"`
-	} `json:"color_temperature,omitempty"`
+	Color                 *Color            `json:"color,omitempty"`
+	ColorTemperature      *ColorTemperature `json:"color_temperature,omitempty"`
 	ColorTemperatureDelta *struct {
 		Action *LightPutColorTemperatureDeltaAction `json:"action,omitempty"`
 

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -1,0 +1,40 @@
+package testing
+
+import "math"
+
+// AlmostEqual32 returns true if a and b are equal within a relative error of e.
+// See http://floating-point-gui.de/errors/comparison/ for the details of the applied method.
+func AlmostEqual32(a, b, e float32) bool {
+
+	MinNormal32 := math.Float32frombits(0x00800000)
+
+	if a == b {
+		return true
+	}
+	absA := Abs32(a)
+	absB := Abs32(b)
+	diff := Abs32(a - b)
+	if a == 0 || b == 0 || absA+absB < MinNormal32 {
+		return diff < e*MinNormal32
+	}
+	return diff/Min32(absA+absB, math.MaxFloat32) < e
+}
+
+// Abs32 works like math.Abs, but for float32.
+func Abs32(x float32) float32 {
+	switch {
+	case x < 0:
+		return -x
+	case x == 0:
+		return 0 // return correctly abs(-0)
+	}
+	return x
+}
+
+// Min32 works like math.Min, but for float32.
+func Min32(x, y float32) float32 {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/util/color/color.go
+++ b/util/color/color.go
@@ -1,0 +1,31 @@
+package color
+
+type RGB struct {
+	Red   int
+	Green int
+	Blue  int
+}
+
+type XY struct {
+	X          float32
+	Y          float32
+	Brightness float32
+}
+
+var UndefinedColor = XY{
+	X:          -1.0,
+	Y:          -1.0,
+	Brightness: -1.0,
+}
+
+// RGBHex Hexadecimal representation of an RGB color. Must start with '#'
+type RGBHex string
+
+// toXY converts a RGBHex value to its XY representation in CIE color space
+func (c *RGBHex) toXY() *XY {
+	hex, err := NewRGBFomHex(string(*c))
+	if err != nil {
+		return nil
+	}
+	return hex.ToXY()
+}

--- a/util/color/color_test.go
+++ b/util/color/color_test.go
@@ -1,0 +1,1 @@
+package color

--- a/util/color/constant.go
+++ b/util/color/constant.go
@@ -1,0 +1,179 @@
+package color
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The Table contains the list of supported colors by name
+var Table = map[RGBHex]*XY{
+	// basic colors
+	"white":   rgb("#FFFFFF").toXY(),
+	"red":     rgb("#FF0000").toXY(),
+	"lime":    rgb("#00FF00").toXY(),
+	"blue":    rgb("#0000FF").toXY(),
+	"yellow":  rgb("#FFFF00").toXY(),
+	"cyan":    rgb("#00FFFF").toXY(),
+	"aqua":    rgb("#00FFFF").toXY(),
+	"magenta": rgb("#FF00FF").toXY(),
+	"fuchsia": rgb("#FF00FF").toXY(),
+	"silver":  rgb("#C0C0C0").toXY(),
+	"gray":    rgb("#FF00FF").toXY(),
+	"maroon":  rgb("#808080").toXY(),
+	"olive":   rgb("#808000").toXY(),
+	"green":   rgb("#008000").toXY(),
+	"purple":  rgb("#800080").toXY(),
+	"teal":    rgb("#008080").toXY(),
+	"navy":    rgb("#000080").toXY(),
+
+	// more colors
+	"dark_red":                rgb("#8B0000").toXY(),
+	"brown":                   rgb("#A52A2A").toXY(),
+	"firebrick":               rgb("#B22222").toXY(),
+	"crimson":                 rgb("#DC143C").toXY(),
+	"tomato":                  rgb("#FF6347").toXY(),
+	"coral":                   rgb("#FF7F50").toXY(),
+	"indian_red":              rgb("#CD5C5C").toXY(),
+	"light_coral":             rgb("#F08080").toXY(),
+	"dark_salmon":             rgb("#E9967A").toXY(),
+	"salmon":                  rgb("#FA8072").toXY(),
+	"light_salmon":            rgb("#FFA07A").toXY(),
+	"orange_red":              rgb("#FF4500").toXY(),
+	"dark_orange":             rgb("#FF8C00").toXY(),
+	"orange":                  rgb("#FFA500").toXY(),
+	"gold":                    rgb("#FFD700").toXY(),
+	"dark_golden_rod":         rgb("#B8860B").toXY(),
+	"golden_rod":              rgb("#DAA520").toXY(),
+	"pale_golden_rod":         rgb("#EEE8AA").toXY(),
+	"dark_khaki":              rgb("#BDB76B").toXY(),
+	"khaki":                   rgb("#F0E68C").toXY(),
+	"yellow_green":            rgb("#9ACD32").toXY(),
+	"dark_olive_green":        rgb("#556B2F").toXY(),
+	"olive_drab":              rgb("#6B8E23").toXY(),
+	"lawn_green":              rgb("#7CFC00").toXY(),
+	"chartreuse":              rgb("#7FFF00").toXY(),
+	"green_yellow":            rgb("#ADFF2F").toXY(),
+	"dark_green":              rgb("#006400").toXY(),
+	"forest_green":            rgb("#228B22").toXY(),
+	"lime_green":              rgb("#32CD32").toXY(),
+	"light_green":             rgb("#90EE90").toXY(),
+	"pale_green":              rgb("#98FB98").toXY(),
+	"dark_sea_green":          rgb("#8FBC8F").toXY(),
+	"medium_spring_green":     rgb("#00FA9A").toXY(),
+	"spring_green":            rgb("#00FF7F").toXY(),
+	"sea_green":               rgb("#2E8B57").toXY(),
+	"medium_aqua_marine":      rgb("#66CDAA").toXY(),
+	"medium_sea_green":        rgb("#3CB371").toXY(),
+	"light_sea_green":         rgb("#20B2AA").toXY(),
+	"dark_slate_gray":         rgb("#2F4F4F").toXY(),
+	"dark_cyan":               rgb("#008B8B").toXY(),
+	"light_cyan":              rgb("#E0FFFF").toXY(),
+	"dark_turquoise":          rgb("#00CED1").toXY(),
+	"turquoise":               rgb("#40E0D0").toXY(),
+	"medium_turquoise":        rgb("#48D1CC").toXY(),
+	"pale_turquoise":          rgb("#AFEEEE").toXY(),
+	"aqua_marine":             rgb("#7FFFD4").toXY(),
+	"powder_blue":             rgb("#B0E0E6").toXY(),
+	"cadet_blue":              rgb("#5F9EA0").toXY(),
+	"steel_blue":              rgb("#4682B4").toXY(),
+	"corn_flower_blue":        rgb("#6495ED").toXY(),
+	"deep_sky_blue":           rgb("#00BFFF").toXY(),
+	"dodger_blue":             rgb("#1E90FF").toXY(),
+	"light_blue":              rgb("#ADD8E6").toXY(),
+	"sky_blue":                rgb("#87CEEB").toXY(),
+	"light_sky_blue":          rgb("#87CEFA").toXY(),
+	"midnight_blue":           rgb("#191970").toXY(),
+	"dark_blue":               rgb("#00008B").toXY(),
+	"medium_blue":             rgb("#0000CD").toXY(),
+	"royal_blue":              rgb("#4169E1").toXY(),
+	"blue_violet":             rgb("#8A2BE2").toXY(),
+	"indigo":                  rgb("#4B0082").toXY(),
+	"dark_slate_blue":         rgb("#483D8B").toXY(),
+	"slate_blue":              rgb("#6A5ACD").toXY(),
+	"medium_slate_blue":       rgb("#7B68EE").toXY(),
+	"medium_purple":           rgb("#9370DB").toXY(),
+	"dark_magenta":            rgb("#8B008B").toXY(),
+	"dark_violet":             rgb("#9400D3").toXY(),
+	"dark_orchid":             rgb("#9932CC").toXY(),
+	"medium_orchid":           rgb("#BA55D3").toXY(),
+	"thistle":                 rgb("#D8BFD8").toXY(),
+	"plum":                    rgb("#DDA0DD").toXY(),
+	"violet":                  rgb("#EE82EE").toXY(),
+	"orchid":                  rgb("#DA70D6").toXY(),
+	"medium_violet_red":       rgb("#C71585").toXY(),
+	"pale_violet_red":         rgb("#DB7093").toXY(),
+	"deep_pink":               rgb("#FF1493").toXY(),
+	"hot_pink":                rgb("#FF69B4").toXY(),
+	"light_pink":              rgb("#FFB6C1").toXY(),
+	"pink":                    rgb("#FFC0CB").toXY(),
+	"antique_white":           rgb("#FAEBD7").toXY(),
+	"beige":                   rgb("#F5F5DC").toXY(),
+	"bisque":                  rgb("#FFE4C4").toXY(),
+	"blanched_almond":         rgb("#FFEBCD").toXY(),
+	"wheat":                   rgb("#F5DEB3").toXY(),
+	"corn_silk":               rgb("#FFF8DC").toXY(),
+	"lemon_chiffon":           rgb("#FFFACD").toXY(),
+	"light golden rod yellow": rgb("#FAFAD2").toXY(),
+	"light_yellow":            rgb("#FFFFE0").toXY(),
+	"saddle_brown":            rgb("#8B4513").toXY(),
+	"sienna":                  rgb("#A0522D").toXY(),
+	"chocolate":               rgb("#D2691E").toXY(),
+	"peru":                    rgb("#CD853F").toXY(),
+	"sandy_brown":             rgb("#F4A460").toXY(),
+	"burly_wood":              rgb("#DEB887").toXY(),
+	"tan":                     rgb("#D2B48C").toXY(),
+	"rosy_brown":              rgb("#BC8F8F").toXY(),
+	"moccasin":                rgb("#FFE4B5").toXY(),
+	"navajo_white":            rgb("#FFDEAD").toXY(),
+	"peach_puff":              rgb("#FFDAB9").toXY(),
+	"misty_rose":              rgb("#FFE4E1").toXY(),
+	"lavender_blush":          rgb("#FFF0F5").toXY(),
+	"linen":                   rgb("#FAF0E6").toXY(),
+	"old_lace":                rgb("#FDF5E6").toXY(),
+	"papaya_whip":             rgb("#FFEFD5").toXY(),
+	"sea_shell":               rgb("#FFF5EE").toXY(),
+	"mint_cream":              rgb("#F5FFFA").toXY(),
+	"slate_gray":              rgb("#708090").toXY(),
+	"light_slate_gray":        rgb("#778899").toXY(),
+	"light_steel_blue":        rgb("#B0C4DE").toXY(),
+	"lavender":                rgb("#E6E6FA").toXY(),
+	"floral_white":            rgb("#FFFAF0").toXY(),
+	"alice_blue":              rgb("#F0F8FF").toXY(),
+	"ghost_white":             rgb("#F8F8FF").toXY(),
+	"honeydew":                rgb("#F0FFF0").toXY(),
+	"ivory":                   rgb("#FFFFF0").toXY(),
+	"azure":                   rgb("#F0FFFF").toXY(),
+	"snow":                    rgb("#FFFAFA").toXY(),
+	"dim_gray":                rgb("#696969").toXY(),
+	"dark_gray":               rgb("#A9A9A9").toXY(),
+	"light_gray":              rgb("#D3D3D3").toXY(),
+	"gainsboro":               rgb("#DCDCDC").toXY(),
+	"white_smoke":             rgb("#F5F5F5").toXY(),
+}
+
+// GetSupportColorList returns the list of the supported colors contained in the Table map
+func GetSupportColorList() []string {
+	colors := make([]string, len(Table))
+	i := 0
+	for c := range Table {
+		colors[i] = string(c)
+		i++
+	}
+	return colors
+}
+
+// FindColorByName helps find a XY color by its name
+func FindColorByName(name string) (*XY, error) {
+	c := Table[RGBHex(name)]
+
+	if c == nil {
+		return nil, fmt.Errorf("color with name '%s' not found. Supported colors: \n%s", name, strings.Join(GetSupportColorList(), ", "))
+	}
+
+	return c, nil
+}
+
+// rgb Local helper function that returns a pointer to a RGBHex value
+func rgb(v RGBHex) *RGBHex {
+	return &v
+}

--- a/util/color/constant_test.go
+++ b/util/color/constant_test.go
@@ -1,0 +1,29 @@
+package color
+
+import (
+	test "openhue-cli/testing"
+	"testing"
+)
+
+func TestFindColorByName(t *testing.T) {
+
+	color, err := FindColorByName("red")
+	if err != nil {
+		t.Fatalf("Color red should exits")
+	}
+	if !test.AlmostEqual32(color.X, 0.640075, 1e-6) {
+		t.Fatalf("X for red should be %f", color.X)
+	}
+	if !test.AlmostEqual32(color.Y, 0.329971, 1e-6) {
+		t.Fatalf("Y for red should be %f", color.Y)
+	}
+}
+
+func TestCannotFindColorByName(t *testing.T) {
+
+	_, err := FindColorByName("foobar")
+	if err == nil {
+		t.Fatalf("foobar color should not exist")
+	}
+
+}

--- a/util/color/conversion.go
+++ b/util/color/conversion.go
@@ -1,0 +1,60 @@
+package color
+
+import (
+	"errors"
+	"math"
+	"strconv"
+)
+
+// ToXY RGB to XY conversion
+// Based on https://developers.meethue.com/develop/application-design-guidance/color-conversion-formulas-rgb-to-xy-and-back/
+func (c *RGB) ToXY() *XY {
+
+	red := 1.0 - (255-float32(c.Red))/255
+	green := 1.0 - (255-float32(c.Green))/255
+	blue := 1.0 - (255-float32(c.Blue))/255
+
+	// Gamma correction
+	gammaCorrection(&red)
+	gammaCorrection(&green)
+	gammaCorrection(&blue)
+
+	// Convert the RGB values to XYZ using the Wide RGB D65 conversion formula
+	X := red*0.4124 + green*0.3576 + blue*0.1805
+	Y := red*0.2126 + green*0.7152 + blue*0.0722
+	Z := red*0.0193 + green*0.1192 + blue*0.9505
+
+	// Calculate the xy values from the XYZ values
+	return &XY{
+		X:          X / (X + Y + Z),
+		Y:          Y / (X + Y + Z),
+		Brightness: Y,
+	}
+}
+
+// NewRGBFomHex Converts a hexadecimal string representation of a color to its RGB value.
+// Example: #FF0000 will return RGB{255, 0, 0}
+func NewRGBFomHex(hex string) (*RGB, error) {
+
+	if !(hex[0:1] == "#") && len(hex) != 7 {
+		return nil, errors.New("wrong format for the input hexadecimal string")
+	}
+
+	r, _ := strconv.ParseInt(hex[1:3], 16, 32)
+	g, _ := strconv.ParseInt(hex[3:5], 16, 32)
+	b, _ := strconv.ParseInt(hex[5:7], 16, 32)
+
+	return &RGB{
+		int(r),
+		int(g),
+		int(b),
+	}, nil
+}
+
+func gammaCorrection(color *float32) {
+	if *color > 0.04045 {
+		*color = float32(math.Pow((float64(*color)+0.055)/(1.0+0.055), 2.4))
+	} else {
+		*color = *color / 12.92
+	}
+}

--- a/util/color/conversion_test.go
+++ b/util/color/conversion_test.go
@@ -1,0 +1,42 @@
+package color
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRGBToXY(t *testing.T) {
+
+	red := RGB{
+		255,
+		0,
+		0,
+	}
+
+	xy := red.ToXY()
+
+	fmt.Println(xy)
+}
+
+func TestNewRGBFromHex(t *testing.T) {
+	assertRGBFromHexString(t, "#330033", 51, 0, 51)
+	assertRGBFromHexString(t, "#FF0000", 255, 0, 0)
+	assertRGBFromHexString(t, "#00FF00", 0, 255, 0)
+	assertRGBFromHexString(t, "#0000FF", 0, 0, 255)
+	assertRGBFromHexString(t, "#FFFFFF", 255, 255, 255)
+	assertRGBFromHexString(t, "#000000", 0, 0, 0)
+}
+
+func assertRGBFromHexString(t *testing.T, hexStr string, r int, g int, b int) {
+	rgb, _ := NewRGBFomHex(hexStr)
+
+	if rgb.Red != r {
+		t.Fatalf("Red should be %d, obtained value is %d", r, rgb.Red)
+	}
+	if rgb.Green != g {
+		t.Fatalf("Green should be %d, obtained value is %d", g, rgb.Green)
+	}
+	if rgb.Blue != b {
+		t.Fatalf("Blue should be %d, obtained value is %d", b, rgb.Blue)
+	}
+}


### PR DESCRIPTION
Examples: 
```shell
# Set color (in RGB) of a single light
openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --rgb #3399FF

# Set color (in CIE space) of a single light
openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on -x 0.675 -y 0.322

# Set color (by name) of a single light
openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue
```