### PR TITLE
The config command outputs the path to the config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,7 @@ func Execute(buildInfo *openhue.BuildInfo) {
 	root.AddCommand(version.NewCmdVersion(ctx))
 	root.AddCommand(setup.NewCmdSetup(ctx.Io))
 	root.AddCommand(setup.NewCmdDiscover(ctx.Io))
-	root.AddCommand(setup.NewCmdConfigure())
+	root.AddCommand(setup.NewCmdConfigure(ctx.Io))
 
 	root.AddCommand(set.NewCmdSet(ctx))
 	root.AddCommand(get.NewCmdGet(ctx))

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
 )
@@ -19,7 +20,7 @@ type Options struct {
 }
 
 // NewCmdConfigure creates the configure command
-func NewCmdConfigure() *cobra.Command {
+func NewCmdConfigure(io openhue.IOStreams) *cobra.Command {
 
 	o := Options{}
 
@@ -35,8 +36,9 @@ func NewCmdConfigure() *cobra.Command {
 				Key:    o.key,
 			}
 
-			_, err := c.Save()
+			path, err := c.Save()
 			cobra.CheckErr(err)
+			fmt.Fprintln(io.Out, "[OK] Configuration saved in file", path)
 		},
 	}
 

--- a/cmd/setup/config_test.go
+++ b/cmd/setup/config_test.go
@@ -1,13 +1,14 @@
 package setup
 
 import (
+	"openhue-cli/openhue"
 	"openhue-cli/openhue/test/assert"
 	"testing"
 )
 
 func TestNewCmdConfigure(t *testing.T) {
 
-	cmd := NewCmdConfigure()
+	cmd := NewCmdConfigure(openhue.NewTestIOStreamsDiscard())
 
 	assert.ThatCmdUseIs(t, cmd, "config")
 	assert.ThatCmdGroupIs(t, cmd, "config")


### PR DESCRIPTION
Usage: 
```bash
openhue config --bridge 192.168.1.100 --key xxx
```
Result: 
```
[OK] Configuration saved in file /home/.openhue/config.yaml
```