### PR TITLE
The setup command now allows the set the bridge IP using the --bridge flag parameter

### DIFF
--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -1,7 +1,6 @@
 package setup
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
 )
@@ -38,7 +37,7 @@ func NewCmdConfigure(io openhue.IOStreams) *cobra.Command {
 
 			path, err := c.Save()
 			cobra.CheckErr(err)
-			fmt.Fprintln(io.Out, "[OK] Configuration saved in file", path)
+			io.Println("[OK] Configuration saved in file", path)
 		},
 	}
 

--- a/cmd/setup/discover.go
+++ b/cmd/setup/discover.go
@@ -1,7 +1,6 @@
 package setup
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 	"net"
 	"openhue-cli/openhue"
@@ -21,7 +20,7 @@ func NewCmdDiscover(io openhue.IOStreams) *cobra.Command {
 
 			ip := make(chan *net.IP)
 			go mdns.DiscoverBridge(ip, 5*time.Second)
-			fmt.Fprintf(io.Out, "%s\n", <-ip)
+			io.Printf("%s\n", <-ip)
 		},
 	}
 

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -14,9 +14,12 @@ import (
 	"time"
 )
 
+const hueBridgeDiscover = "https://discovery.meethue.com"
+
 type CmdSetupOptions struct {
 	deviceType        string
 	generateClientKey bool
+	bridge            string
 }
 
 func NewCmdSetup(io openhue.IOStreams) *cobra.Command {
@@ -38,43 +41,63 @@ the bridge button to perform initial pairing.
 
 	cmd.Flags().StringVarP(&o.deviceType, "devicetype", "d", getHostName(), "Device identifier")
 	cmd.Flags().BoolVarP(&o.generateClientKey, "generateclientkey", "k", true, "Generate the client key")
+	cmd.Flags().StringVarP(&o.bridge, "bridge", "b", "", "Set your Hue Bridge IP address ("+hueBridgeDiscover+")")
 
 	return cmd
 }
 
 func startSetup(io openhue.IOStreams, o *CmdSetupOptions) {
+	ip, err := getBridgeIPAddress(io, o)
+	if err != nil {
+		io.ErrPrintln(err.Error())
+		return
+	}
+
+	client := openhue.NewOpenHueClientNoAuth(ip)
+
+	io.Println("[..] Please push the button on your Hue Bridge")
+	for {
+		key, retry, err := tryAuth(client, o.toAuthenticateBody())
+		if err != nil && retry {
+			// this is an expected error, we just wait for the user to push the button
+			io.Printf(".")
+			time.Sleep(1 * time.Second)
+			continue
+		} else if err != nil && !retry {
+			// this is unexpected, let's print the error and exit
+			io.ErrPrintln(err.Error())
+			break
+		}
+		io.Println("\n[OK] Successfully paired openhue with your Hue Bridge!")
+		path, err := saveConfig(ip, key)
+		if err != nil {
+			io.ErrPrintln("[KO] Unable to save config")
+		}
+		io.Println("[OK] Configuration saved in file", path)
+		break
+	}
+}
+
+func getBridgeIPAddress(io openhue.IOStreams, o *CmdSetupOptions) (string, error) {
+
+	if len(o.bridge) > 0 {
+		log.Infof("Bridge IP address set from flag --bridge with value %s", o.bridge)
+		io.Printf("[OK] Bridge IP is '%s'\n", o.bridge)
+		return o.bridge, nil
+	}
+
+	log.Info("Bridge IP address no set from flag --bridge, start lookup via mDNS service discovery")
+
 	ipChan := make(chan *net.IP)
 	go mdns.DiscoverBridge(ipChan, 5*time.Second)
 	ip := <-ipChan
 
 	if ip == nil {
-		fmt.Fprintf(io.ErrOut, "❌ Unable to discover your Hue Bridge on your local network\n")
-		return
+		return "", fmt.Errorf("[KO] Unable to discover your Hue Bridge on your local network, you can also visit %s\n", hueBridgeDiscover)
 	}
 
-	fmt.Fprintf(io.Out, "[OK] Found Hue Bridge with IP '%s'\n", ip)
-
-	client := openhue.NewOpenHueClientNoAuth(ip.String())
-
-	fmt.Fprintln(io.Out, "[..] Please push the button on your Hue Bridge")
-	done := false
-	for done == false {
-		fmt.Fprintf(io.Out, ".")
-		key, err := tryAuth(client, o.toAuthenticateBody())
-		if err != nil {
-			time.Sleep(1 * time.Second)
-			continue
-		}
-		done = true
-		fmt.Fprintf(io.Out, "\n")
-		log.Info("Hue Application Key is ", key)
-		fmt.Fprintln(io.Out, "[OK] Successfully paired openhue with your Hue Bridge!")
-		path, err := saveConfig(ip.String(), key)
-		if err != nil {
-			fmt.Fprintf(io.ErrOut, "[KO] Unable to save config")
-		}
-		fmt.Fprintln(io.Out, "[OK] Configuration saved in file", path)
-	}
+	io.Printf("[OK] Found Hue Bridge with IP '%s'\n", ip)
+	return ip.String(), nil
 }
 
 func (o *CmdSetupOptions) toAuthenticateBody() gen.AuthenticateJSONRequestBody {
@@ -84,17 +107,21 @@ func (o *CmdSetupOptions) toAuthenticateBody() gen.AuthenticateJSONRequestBody {
 	return body
 }
 
-func tryAuth(client *gen.ClientWithResponses, body gen.AuthenticateJSONRequestBody) (string, error) {
+func tryAuth(client *gen.ClientWithResponses, body gen.AuthenticateJSONRequestBody) (string, bool, error) {
 
 	resp, err := client.AuthenticateWithResponse(context.Background(), body)
 	cobra.CheckErr(err)
 
-	auth := (*resp.JSON200)[0]
-	if auth.Error != nil {
-		return "", errors.New(*auth.Error.Description)
+	if resp.JSON200 == nil {
+		return "", false, fmt.Errorf("[KO] Unable to reach the Bridge, verify that the IP is correct. You can verify it via %s", hueBridgeDiscover)
 	}
 
-	return *auth.Success.Username, nil
+	auth := (*resp.JSON200)[0]
+	if auth.Error != nil {
+		return "", true, errors.New(*auth.Error.Description)
+	}
+
+	return *auth.Success.Username, false, nil
 }
 
 func saveConfig(bridge string, key string) (string, error) {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
 )
@@ -22,9 +21,9 @@ openhue version
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			fmt.Fprintln(ctx.Io.Out, "\n#  Version\t", ctx.BuildInfo.Version)
-			fmt.Fprintln(ctx.Io.Out, "#   Commit\t", BaseCommitUrl+ctx.BuildInfo.Commit)
-			fmt.Fprintln(ctx.Io.Out, "# Built at\t", ctx.BuildInfo.Date)
+			ctx.Io.Println("\n#  Version\t", ctx.BuildInfo.Version)
+			ctx.Io.Println("#   Commit\t", BaseCommitUrl+ctx.BuildInfo.Commit)
+			ctx.Io.Println("# Built at\t", ctx.BuildInfo.Date)
 		},
 	}
 

--- a/openhue/io.go
+++ b/openhue/io.go
@@ -2,13 +2,24 @@ package openhue
 
 import (
 	"bytes"
+	"fmt"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 )
 
+type Console interface {
+	Printf(format string, a ...any)
+	Println(a ...any)
+
+	ErrPrintf(format string, a ...any)
+	ErrPrintln(a ...any)
+}
+
 // IOStreams provides the standard names for io streams.
 // This is useful for embedding and for unit testing.
 type IOStreams struct {
+	Console
 	// In think, os.Stdin
 	In io.Reader
 	// Out think, os.Stdout
@@ -46,5 +57,41 @@ func NewTestIOStreamsDiscard() IOStreams {
 		In:     in,
 		Out:    io.Discard,
 		ErrOut: io.Discard,
+	}
+}
+
+//
+// Console implementation
+//
+
+func (io *IOStreams) Printf(format string, a ...any) {
+	_, err := fmt.Fprintf(io.Out, format, a...)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+}
+
+func (io *IOStreams) Println(a ...any) {
+	_, err := fmt.Fprintln(io.Out, a...)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+}
+
+func (io *IOStreams) ErrPrintf(format string, a ...any) {
+	_, err := fmt.Fprintf(io.ErrOut, format, a...)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+}
+
+func (io *IOStreams) ErrPrintln(a ...any) {
+	_, err := fmt.Fprintln(io.ErrOut, a...)
+	if err != nil {
+		log.Error(err)
+		return
 	}
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -17,16 +17,16 @@ func PrintJsonArray[T any](streams openhue.IOStreams, array []T) {
 	}
 }
 
-func PrintJson[T any](streams openhue.IOStreams, array T) {
+func PrintJson[T any](io openhue.IOStreams, array T) {
 	var out []byte
 	out, _ = json.MarshalIndent(array, "", "  ")
-	fmt.Fprintln(streams.Out, string(out))
+	io.Println(string(out))
 }
 
 // PrintTable prints each line of the objects contained in the table value
-func PrintTable[T any](streams openhue.IOStreams, table []T, lineFn func(T) string, header ...string) {
+func PrintTable[T any](io openhue.IOStreams, table []T, lineFn func(T) string, header ...string) {
 
-	w := tabwriter.NewWriter(streams.Out, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(io.Out, 0, 0, 3, ' ', 0)
 
 	for _, h := range header {
 		_, _ = fmt.Fprint(w, h+"\t")


### PR DESCRIPTION
Usage: 
```bash
openhue setup --bridge 192.168.1.100
```
or 
```bash
openhue setup -b 192.168.1.100
```