### PR TITLE
Added the 'set room' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,7 @@ endif
 .PHONY: clean
 clean: ##
 	@rm -rf ./dist
+	@rm -f c.out
+	@rm -f coverage.html
 	@$(GO) clean
 	@echo "\n${GREEN}${BOLD}Project successfully cleaned 🧹${RESET} (removed ./dist folder + go clean)"

--- a/cmd/get/get_light.go
+++ b/cmd/get/get_light.go
@@ -46,6 +46,7 @@ func NewCmdGetLight(ctx *openhue.Context, co *CmdGetOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "light [lightId]",
+		Aliases: []string{"lights"},
 		Short:   "Get light",
 		Long:    docLongGetLight,
 		Example: docExampleGetLight,
@@ -71,7 +72,7 @@ func (o *LightOptions) RunGetLightCmd(ctx *openhue.Context) {
 	if len(o.LightParam) > 0 {
 
 		if *o.Name {
-			lights = openhue.FindLightByName(ctx.Home, o.LightParam)
+			lights = openhue.FindLightsByName(ctx.Home, []string{o.LightParam})
 		} else {
 			lights = openhue.FindLightsByIds(ctx.Home, []string{o.LightParam})
 		}

--- a/cmd/get/get_room.go
+++ b/cmd/get/get_room.go
@@ -46,6 +46,7 @@ func NewCmdGetRoom(ctx *openhue.Context, co *CmdGetOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "room [roomId]",
+		Aliases: []string{"rooms"},
 		Short:   "Get room",
 		Long:    docLongGetRoom,
 		Example: docExampleGetRoom,
@@ -72,9 +73,9 @@ func (o *RoomOptions) RunGetRoomCmd(ctx *openhue.Context) {
 	if len(o.RoomParam) > 0 {
 
 		if *o.Name {
-			rooms = openhue.FindRoomByName(ctx.Home, o.RoomParam)
+			rooms = openhue.FindRoomsByName(ctx.Home, []string{o.RoomParam})
 		} else {
-			rooms = openhue.FindRoomById(ctx.Home, o.RoomParam)
+			rooms = openhue.FindRoomsByIds(ctx.Home, []string{o.RoomParam})
 		}
 
 	} else {

--- a/cmd/set/common.go
+++ b/cmd/set/common.go
@@ -1,0 +1,103 @@
+package set
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"openhue-cli/openhue"
+	"openhue-cli/util/color"
+)
+
+//
+// Set Light flags, used by the 'set light' and 'set room' commands
+//
+
+type CmdSetLightFlags struct {
+	On         bool
+	Off        bool
+	Brightness float32
+	Rgb        string
+	X          float32
+	Y          float32
+	ColorName  string
+}
+
+func (flags *CmdSetLightFlags) initCmd(cmd *cobra.Command) {
+	// on/off flags
+	cmd.Flags().BoolVar(&flags.On, "on", false, "Turn on the lights")
+	cmd.Flags().BoolVar(&flags.Off, "off", false, "Turn off the lights")
+	cmd.MarkFlagsMutuallyExclusive("on", "off")
+
+	// Brightness flag
+	cmd.Flags().Float32VarP(&flags.Brightness, "brightness", "b", -1, "Set the brightness [min=0, max=100]")
+
+	//
+	// Color flags
+	//
+
+	// rgb
+	cmd.Flags().StringVar(&flags.Rgb, "rgb", "", "RGB hexadecimal value (example #CCE5FF)")
+
+	// xy
+	cmd.Flags().Float32VarP(&flags.X, "cie-x", "x", -1, "X coordinate in the CIE color space (example 0.675)")
+	cmd.Flags().Float32VarP(&flags.Y, "cie-y", "y", -1, "Y coordinate in the CIE color space (example 0.322)")
+	cmd.MarkFlagsRequiredTogether("cie-x", "cie-y")
+
+	// name
+	cmd.Flags().StringVarP(&flags.ColorName, "color", "c", "", "Color name. Allowed: white, lime, green, blue, etc.")
+	_ = cmd.RegisterFlagCompletionFunc("color", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return color.GetSupportColorList(), cobra.ShellCompDirectiveDefault
+	})
+
+	// exclusions
+	cmd.MarkFlagsMutuallyExclusive("color", "rgb", "cie-x")
+}
+
+// toSetLightOptions makes sure provided values for LightOptions are valid
+func (flags *CmdSetLightFlags) toSetLightOptions() (*openhue.SetLightOptions, error) {
+
+	o := openhue.NewSetLightOptions()
+
+	if flags.On {
+		o.Status = openhue.LightStatusOn
+	}
+
+	if flags.Off {
+		o.Status = openhue.LightStatusOff
+	}
+
+	// validate the --brightness flag
+	if flags.Brightness > 100.0 || (flags.Brightness != -1 && flags.Brightness < 0) {
+		return nil, fmt.Errorf("--brightness flag must be greater than 0.0 and lower than 100.0, current value is %.2f", flags.Brightness)
+	} else {
+		o.Brightness = flags.Brightness
+	}
+
+	// color in RGB
+	if flags.Rgb != "" {
+		rgb, err := color.NewRGBFomHex(flags.Rgb)
+		if err != nil {
+			return nil, err
+		}
+		o.Color = *rgb.ToXY()
+	}
+
+	// color in CIE space
+	if flags.X >= 0 && flags.Y >= 0 {
+		o.Color = color.XY{
+			X: flags.X,
+			Y: flags.Y,
+		}
+	}
+
+	// color from enum
+	if flags.ColorName != "" {
+		c, err := color.FindColorByName(flags.ColorName)
+		cobra.CheckErr(err)
+		o.Color = color.XY{
+			X: c.X,
+			Y: c.Y,
+		}
+	}
+
+	return o, nil
+}

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -5,8 +5,15 @@ import (
 	"openhue-cli/openhue"
 )
 
+// CmdSetOptions contains common flags for all 'set' sub commands
+type CmdSetOptions struct {
+	Name bool
+}
+
 // NewCmdSet returns an initialized Command instance for 'set' sub command
 func NewCmdSet(ctx *openhue.Context) *cobra.Command {
+
+	o := &CmdSetOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "set",
@@ -18,7 +25,10 @@ Set the values for a specific resource
 `,
 	}
 
-	cmd.AddCommand(NewCmdSetLight(ctx))
+	cmd.PersistentFlags().BoolVarP(&o.Name, "name", "n", false, "Set resource(s) by name")
+
+	cmd.AddCommand(NewCmdSetLight(ctx, o))
+	cmd.AddCommand(NewCmdSetRoom(ctx, o))
 
 	return cmd
 }

--- a/cmd/set/set_light.go
+++ b/cmd/set/set_light.go
@@ -1,10 +1,9 @@
 package set
 
 import (
-	"fmt"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
-	"openhue-cli/util/color"
 )
 
 const (
@@ -23,8 +22,8 @@ openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on
 # Turn on multiple lights
 openhue set light 83111103-a3eb-40c5-b22a-02deedd21fcb 8f0a7b52-df25-4bc7-b94d-0dd1a88068ff --on
 
-# Turn off a light
-openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --off
+# Turn off a light identified by its name
+openhue set light -n "Hue Play TV" --off
 
 # Set brightness of a single light
 openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65
@@ -40,121 +39,42 @@ openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue
 `
 )
 
-type LightFlags struct {
-	On         bool
-	Off        bool
-	Brightness float32
-	Rgb        string
-	X          float32
-	Y          float32
-	ColorName  string
-}
-
 // NewCmdSetLight returns initialized Command instance for the 'set light' sub command
-func NewCmdSetLight(ctx *openhue.Context) *cobra.Command {
+func NewCmdSetLight(ctx *openhue.Context, setOpt *CmdSetOptions) *cobra.Command {
 
-	f := LightFlags{}
+	f := CmdSetLightFlags{}
 
 	cmd := &cobra.Command{
 		Use:     "light [lightId]",
+		Aliases: []string{"lights"},
 		Short:   docShort,
 		Long:    docLong,
 		Example: docExample,
 		Args:    cobra.MatchAll(cobra.RangeArgs(1, 10), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
-			o, err := PrepareCmdSetLight(&f)
+			o, err := f.toSetLightOptions()
 			cobra.CheckErr(err)
 
-			lights := openhue.FindLightsByIds(ctx.Home, args)
+			var lights []openhue.Light
+
+			if setOpt.Name {
+				lights = openhue.FindLightsByName(ctx.Home, args)
+			} else {
+				lights = openhue.FindLightsByIds(ctx.Home, args)
+			}
+
+			if len(lights) == 0 {
+				ctx.Io.ErrPrintln("no light(s) found for given ID(s)", args)
+			}
 
 			for _, light := range lights {
+				log.Info("set light ", light.Id)
 				light.Set(o)
 			}
 		},
 	}
 
-	f.InitFlags(cmd)
+	f.initCmd(cmd)
 
 	return cmd
-}
-
-func (f *LightFlags) InitFlags(cmd *cobra.Command) {
-	// on/off flags
-	cmd.Flags().BoolVar(&f.On, "on", false, "Turn on the lights")
-	cmd.Flags().BoolVar(&f.Off, "off", false, "Turn off the lights")
-	cmd.MarkFlagsMutuallyExclusive("on", "off")
-
-	// Brightness flag
-	cmd.Flags().Float32VarP(&f.Brightness, "brightness", "b", -1, "Set the brightness [min=0, max=100]")
-
-	//
-	// Color flags
-	//
-
-	// rgb
-	cmd.Flags().StringVar(&f.Rgb, "rgb", "", "RGB hexadecimal value (example #CCE5FF)")
-
-	// xy
-	cmd.Flags().Float32VarP(&f.X, "cie-x", "x", -1, "X coordinate in the CIE color space (example 0.675)")
-	cmd.Flags().Float32VarP(&f.Y, "cie-y", "y", -1, "Y coordinate in the CIE color space (example 0.322)")
-	cmd.MarkFlagsRequiredTogether("cie-x", "cie-y")
-
-	// name
-	cmd.Flags().StringVarP(&f.ColorName, "color", "c", "", "Color name. Allowed: white, lime, green, blue, etc.")
-	_ = cmd.RegisterFlagCompletionFunc("color", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return color.GetSupportColorList(), cobra.ShellCompDirectiveDefault
-	})
-
-	// exclusions
-	cmd.MarkFlagsMutuallyExclusive("color", "rgb", "cie-x")
-}
-
-// PrepareCmdSetLight makes sure provided values for LightOptions are valid
-func PrepareCmdSetLight(flags *LightFlags) (*openhue.SetLightOptions, error) {
-
-	o := openhue.NewSetLightOptions()
-
-	if flags.On {
-		o.Status = openhue.LightStatusOn
-	}
-
-	if flags.Off {
-		o.Status = openhue.LightStatusOff
-	}
-
-	// validate the --brightness flag
-	if flags.Brightness > 100.0 || (flags.Brightness != -1 && flags.Brightness < 0) {
-		return nil, fmt.Errorf("--brightness flag must be greater than 0.0 and lower than 100.0, current value is %.2f", o.Brightness)
-	} else {
-		o.Brightness = flags.Brightness
-	}
-
-	// color in RGB
-	if flags.Rgb != "" {
-		rgb, err := color.NewRGBFomHex(flags.Rgb)
-		if err != nil {
-			return nil, err
-		}
-		o.Color = *rgb.ToXY()
-	}
-
-	// color in CIE space
-	if flags.X >= 0 && flags.Y >= 0 {
-		o.Color = color.XY{
-			X: flags.X,
-			Y: flags.Y,
-		}
-	}
-
-	// color from enum
-	if flags.ColorName != "" {
-		c, err := color.FindColorByName(flags.ColorName)
-		cobra.CheckErr(err)
-		o.Color = color.XY{
-			X: c.X,
-			Y: c.Y,
-		}
-	}
-
-	return o, nil
 }

--- a/cmd/set/set_room.go
+++ b/cmd/set/set_room.go
@@ -1,0 +1,78 @@
+package set
+
+import (
+	"github.com/spf13/cobra"
+	"openhue-cli/openhue"
+)
+
+const (
+	setRoomDocShort = "Update one or multiple rooms (on/off, brightness, color)"
+	setRoomDocLong  = `
+Update one or multiple rooms (max is 10 rooms simultaneously).
+
+ You must set the --on flag in order to turn a room on, even if you set the brightness or the color values.
+    
+Use "openhue get room" for a complete list of available rooms.
+`
+	setRoomDocExample = `
+# Turn on a room
+openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on
+
+# Turn on multiple rooms
+openhue set room 83111103-a3eb-40c5-b22a-02deedd21fcb 8f0a7b52-df25-4bc7-b94d-0dd1a88068ff --on
+
+# Turn off a room identified by its name
+openhue set room -n Studio --off
+
+# Set brightness of a single room
+openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65
+
+# Set color (in RGB) of a single room
+openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --rgb #3399FF
+
+# Set color (in CIE space) of a single room
+openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on -x 0.675 -y 0.322
+
+# Set color (by name) of a single room
+openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue
+`
+)
+
+// NewCmdSetRoom returns initialized cobra.Command instance for the 'set room' sub command
+func NewCmdSetRoom(ctx *openhue.Context, setOpt *CmdSetOptions) *cobra.Command {
+
+	f := CmdSetLightFlags{}
+
+	cmd := &cobra.Command{
+		Use:     "room [roomId]",
+		Aliases: []string{"rooms"},
+		Short:   setRoomDocShort,
+		Long:    setRoomDocLong,
+		Example: setRoomDocExample,
+		Args:    cobra.MatchAll(cobra.RangeArgs(1, 10), cobra.OnlyValidArgs),
+		Run: func(cmd *cobra.Command, args []string) {
+			o, err := f.toSetLightOptions()
+			cobra.CheckErr(err)
+
+			var rooms []openhue.Room
+
+			if setOpt.Name {
+				rooms = openhue.FindRoomsByName(ctx.Home, args)
+			} else {
+				rooms = openhue.FindRoomsByIds(ctx.Home, args)
+			}
+
+			if len(rooms) == 0 {
+				ctx.Io.ErrPrintln("no room(s) found for given ID(s)", args)
+			}
+
+			for _, room := range rooms {
+				room.GroupedLight.Set(o)
+			}
+		},
+	}
+
+	f.initCmd(cmd)
+
+	return cmd
+}

--- a/openhue/home_model.go
+++ b/openhue/home_model.go
@@ -147,7 +147,7 @@ func (groupedLight *GroupedLight) IsOn() bool {
 	return *groupedLight.HueData.On.On
 }
 
-func (groupedLight *GroupedLight) Set(o SetLightOptions) {
+func (groupedLight *GroupedLight) Set(o *SetLightOptions) {
 	request := &gen.UpdateGroupedLightJSONRequestBody{}
 
 	if o.Status != LightStatusUndefined {

--- a/openhue/home_service.go
+++ b/openhue/home_service.go
@@ -47,20 +47,21 @@ func FindAllLights(home *Home) []Light {
 	return lights
 }
 
-// FindLightByName returns a slice containing a single Light. The slice will be empty if no light was found.
-func FindLightByName(home *Home, name string) []Light {
+func FindLightsByName(home *Home, ids []string) []Light {
+
+	var lights []Light
+
 	for _, room := range home.Rooms {
 		for _, device := range room.Devices {
 			if device.Light != nil {
-				if device.Light.Name == name {
-					return []Light{*device.Light}
+				if slices.Contains(ids, device.Light.Name) {
+					lights = append(lights, *device.Light)
 				}
 			}
 		}
 	}
 
-	log.Warn("no light found with name ", name)
-	return []Light{}
+	return lights
 }
 
 func FindLightsByIds(home *Home, ids []string) []Light {
@@ -94,26 +95,30 @@ func FindAllRooms(home *Home) []Room {
 	return rooms
 }
 
-func FindRoomById(home *Home, id string) []Room {
+func FindRoomsByIds(home *Home, ids []string) []Room {
+
+	var rooms []Room
+
 	for _, room := range home.Rooms {
-		if room.Id == id {
-			return []Room{room}
+		if slices.Contains(ids, room.Id) {
+			rooms = append(rooms, room)
 		}
 	}
 
-	log.Warn("no light found with ID ", id)
-	return []Room{}
+	return rooms
 }
 
-func FindRoomByName(home *Home, name string) []Room {
+func FindRoomsByName(home *Home, names []string) []Room {
+
+	var rooms []Room
+
 	for _, room := range home.Rooms {
-		if room.Name == name {
-			return []Room{room}
+		if slices.Contains(names, room.Name) {
+			rooms = append(rooms, room)
 		}
 	}
 
-	log.Warn("no room found with name ", name)
-	return []Room{}
+	return rooms
 }
 
 //

--- a/openhue/home_service_test.go
+++ b/openhue/home_service_test.go
@@ -13,10 +13,10 @@ func TestFindAllLights(t *testing.T) {
 	assert.Len(t, lights, 4, "Home should contain 4 lights")
 }
 
-func TestFindLightByName(t *testing.T) {
-	lights := FindLightByName(home, "room1_light2")
+func TestFindLightsByName(t *testing.T) {
+	lights := FindLightsByName(home, []string{"room1_light2"})
 	assert.Len(t, lights, 1, "Home should contain 1 single light for this name")
-	assert.Empty(t, FindLightByName(home, "foo"), "Home should not contain any light with name 'foo'")
+	assert.Empty(t, FindLightsByName(home, []string{"foo"}), "Home should not contain any light with name 'foo'")
 }
 
 func TestFindLightsByIds(t *testing.T) {
@@ -29,16 +29,16 @@ func TestFindAllRooms(t *testing.T) {
 	assert.Len(t, rooms, 2, "Home should contain 2 rooms")
 }
 
-func TestFindRoomByName(t *testing.T) {
-	rooms := FindRoomByName(home, "room1")
+func TestFindRoomsByName(t *testing.T) {
+	rooms := FindRoomsByName(home, []string{"room1"})
 	assert.Len(t, rooms, 1, "Home should contain 1 single room for this name")
-	assert.Empty(t, FindRoomByName(home, "foo"), "Home should not contain any room with name 'foo'")
+	assert.Empty(t, FindRoomsByName(home, []string{"foo"}), "Home should not contain any room with name 'foo'")
 }
 
 func TestFindRoomById(t *testing.T) {
-	rooms := FindRoomById(home, "room2")
+	rooms := FindRoomsByIds(home, []string{"room2"})
 	assert.Len(t, rooms, 1, "Home should contain 1 single room for this name")
-	assert.Empty(t, FindRoomById(home, "foo"), "Home should not contain any room with ID 'foo'")
+	assert.Empty(t, FindRoomsByIds(home, []string{"foo"}), "Home should not contain any room with ID 'foo'")
 }
 
 //


### PR DESCRIPTION
Usage: 
```
openhue set room -h
```
```
Update one or multiple rooms (max is 10 rooms simultaneously).

 You must set the --on flag in order to turn a room on, even if you set the brightness or the color values.
    
Use "openhue get room" for a complete list of available rooms.

Usage:
  openhue set room [roomId] [flags]

Aliases:
  room, rooms

Examples:

# Turn on a room
openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on

# Turn on multiple rooms
openhue set room 83111103-a3eb-40c5-b22a-02deedd21fcb 8f0a7b52-df25-4bc7-b94d-0dd1a88068ff --on

# Turn off a room identified by its name
openhue set room -n Studio --off

# Set brightness of a single room
openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65

# Set color (in RGB) of a single room
openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --rgb #3399FF

# Set color (in CIE space) of a single room
openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on -x 0.675 -y 0.322

# Set color (by name) of a single room
openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue


Flags:
  -b, --brightness float32   Set the brightness [min=0, max=100] (default -1)
  -x, --cie-x float32        X coordinate in the CIE color space (example 0.675) (default -1)
  -y, --cie-y float32        Y coordinate in the CIE color space (example 0.322) (default -1)
  -c, --color string         Color name. Allowed: white, lime, green, blue, etc.
  -h, --help                 help for room
      --off                  Turn off the lights
      --on                   Turn on the lights
      --rgb string           RGB hexadecimal value (example #CCE5FF)

Global Flags:
  -n, --name   Set resource(s) by name

```