### PR TITLE
Added the 'get scene' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,21 @@ GREEN = "\\033[0\;32m"
 BOLD = "\\033[1m"
 RESET = "\\033[0m"
 
+SPEC_URL = "https://api.redocly.com/registry/bundle/openhue/openhue/v2/openapi.yaml?branch=main"
+
 .PHONY: help
 help:
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "make \033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: generate
-generate: ## Generates the openhue.gen.go client from the latest https://github.com/openhue/openhue-api specification
-	@$(GO) generate
+generate: ## Generates the openhue/gen/openhue.gen.go client. Usage: make generate [spec=/path/to/openhue.yaml]
+ifdef spec
+	@echo "Code generation from $(spec)"
+	@oapi-codegen --package=gen -generate=client,types -o ./openhue/gen/openhue.gen.go "$(spec)"
+else
+	@echo "Code generation from $(SPEC_URL)"
+	@oapi-codegen --package=gen -generate=client,types -o ./openhue/gen/openhue.gen.go "$(SPEC_URL)"
+endif
 	@echo "\n${GREEN}${BOLD}./openhue/openhue.gen.go successfully generated 🚀${RESET}"
 
 .PHONY: build

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -10,7 +10,6 @@ import (
 
 type CmdGetOptions struct {
 	Json bool
-	Name bool
 }
 
 // NewCmdGet returns an initialized Command instance for 'get' sub command
@@ -36,12 +35,12 @@ Retrieve information for any kind of resources exposed by your Hue Bridge: light
 
 	// persistence flags
 	cmd.PersistentFlags().BoolVarP(&o.Json, "json", "j", false, "Format output as JSON")
-	cmd.PersistentFlags().BoolVarP(&o.Name, "name", "n", false, "Get resource(s) by name")
 
 	// sub commands
 	cmd.AddCommand(NewCmdGetEvents(ctx, &o))
 	cmd.AddCommand(NewCmdGetLight(ctx, &o))
 	cmd.AddCommand(NewCmdGetRoom(ctx, &o))
+	cmd.AddCommand(NewCmdGetScene(ctx, &o))
 
 	return cmd
 }

--- a/cmd/get/get_room.go
+++ b/cmd/get/get_room.go
@@ -26,23 +26,8 @@ openhue get room -n "Studio"
 `
 )
 
-type RoomOptions struct {
-	RoomParam string
-	Json      *bool
-	Name      *bool
-}
-
-func NewGetRoomOptions(co *CmdGetOptions) *RoomOptions {
-	return &RoomOptions{
-		Json: &co.Json,
-		Name: &co.Name,
-	}
-}
-
 // NewCmdGetRoom returns initialized Command instance for the 'get light' sub command
-func NewCmdGetRoom(ctx *openhue.Context, co *CmdGetOptions) *cobra.Command {
-
-	o := NewGetRoomOptions(co)
+func NewCmdGetRoom(ctx *openhue.Context, o *CmdGetOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "room [roomId]",
@@ -52,37 +37,18 @@ func NewCmdGetRoom(ctx *openhue.Context, co *CmdGetOptions) *cobra.Command {
 		Example: docExampleGetRoom,
 		Args:    cobra.MatchAll(cobra.RangeArgs(0, 1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
-			o.PrepareGetRoomCmd(args)
-			o.RunGetRoomCmd(ctx)
+			RunGetRoomCmd(ctx, o, args)
 		},
 	}
 
 	return cmd
 }
 
-func (o *RoomOptions) PrepareGetRoomCmd(args []string) {
-	if len(args) > 0 {
-		o.RoomParam = args[0]
-	}
-}
+func RunGetRoomCmd(ctx *openhue.Context, o *CmdGetOptions, args []string) {
 
-func (o *RoomOptions) RunGetRoomCmd(ctx *openhue.Context) {
+	rooms := openhue.SearchRooms(ctx.Home, args)
 
-	var rooms []openhue.Room
-
-	if len(o.RoomParam) > 0 {
-
-		if *o.Name {
-			rooms = openhue.FindRoomsByName(ctx.Home, []string{o.RoomParam})
-		} else {
-			rooms = openhue.FindRoomsByIds(ctx.Home, []string{o.RoomParam})
-		}
-
-	} else {
-		rooms = openhue.FindAllRooms(ctx.Home)
-	}
-
-	if *o.Json {
+	if o.Json {
 		util.PrintJsonArray(ctx.Io, rooms)
 	} else {
 		util.PrintTable(ctx.Io, rooms, PrintRoom, "ID", "Name", "Type", "Status", "Brightness")

--- a/cmd/get/get_scene.go
+++ b/cmd/get/get_scene.go
@@ -1,0 +1,77 @@
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"openhue-cli/openhue"
+	"openhue-cli/util"
+	"strconv"
+)
+
+type SceneOptions struct {
+	*CmdGetOptions
+	Room string
+}
+
+// NewCmdGetScene returns initialized Command instance for the 'get scene' sub command
+func NewCmdGetScene(ctx *openhue.Context, co *CmdGetOptions) *cobra.Command {
+
+	o := SceneOptions{
+		CmdGetOptions: co,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "scene [sceneId]",
+		Aliases: []string{"scenes"},
+		Short:   "Get scenes",
+		Long: `
+Displays all the scenes with their main information, including the room they belong to.
+`,
+		Example: `
+# List all scenes
+openhue get scene
+
+# List all scenes as JSON 
+openhue get scene --json
+
+# Filter scenes for a given room name
+openhue get scenes --room "Living Room"
+
+# Filter scenes for a given room ID
+openhue get scenes -r 878a65d6-613b-4239-8b77-588b535bfb4a
+
+# List multiple scenes using either the ID or the name of the scene
+openhue get scenes "Palm Beach" Nebula 462e54d9-ec5d-4bf6-879d-ad34cb9a692e
+`,
+		Args: cobra.MatchAll(cobra.RangeArgs(0, 100), cobra.OnlyValidArgs),
+		Run: func(cmd *cobra.Command, args []string) {
+			o.RunGetSceneCmd(ctx, args)
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.Room, "room", "r", "", "Filter scenes by room (name or ID)")
+
+	return cmd
+}
+
+func (o *SceneOptions) RunGetSceneCmd(ctx *openhue.Context, args []string) {
+
+	var scenes []openhue.Scene
+
+	scenes = openhue.SearchScenes(ctx.Home, o.Room, args)
+
+	if o.Json {
+		util.PrintJsonArray(ctx.Io, scenes)
+	} else {
+		util.PrintTable(ctx.Io, scenes, PrintScene, "ID", "Name", "Room", "Status", "Speed", "Auto Dynamic")
+	}
+}
+
+func PrintScene(scene openhue.Scene) string {
+
+	return scene.Id +
+		"\t" + scene.Name +
+		"\t" + scene.Parent.Name +
+		"\t" + string(*scene.HueData.Status.Active) +
+		"\t" + strconv.FormatFloat(float64(*scene.HueData.Speed), 'f', 2, 64) +
+		"\t" + strconv.FormatBool(*scene.HueData.AutoDynamic)
+}

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -5,15 +5,8 @@ import (
 	"openhue-cli/openhue"
 )
 
-// CmdSetOptions contains common flags for all 'set' sub commands
-type CmdSetOptions struct {
-	Name bool
-}
-
 // NewCmdSet returns an initialized Command instance for 'set' sub command
 func NewCmdSet(ctx *openhue.Context) *cobra.Command {
-
-	o := &CmdSetOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "set",
@@ -25,10 +18,8 @@ Set the values for a specific resource
 `,
 	}
 
-	cmd.PersistentFlags().BoolVarP(&o.Name, "name", "n", false, "Set resource(s) by name")
-
-	cmd.AddCommand(NewCmdSetLight(ctx, o))
-	cmd.AddCommand(NewCmdSetRoom(ctx, o))
+	cmd.AddCommand(NewCmdSetLight(ctx))
+	cmd.AddCommand(NewCmdSetRoom(ctx))
 
 	return cmd
 }

--- a/cmd/set/set_room.go
+++ b/cmd/set/set_room.go
@@ -22,7 +22,7 @@ openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on
 openhue set room 83111103-a3eb-40c5-b22a-02deedd21fcb 8f0a7b52-df25-4bc7-b94d-0dd1a88068ff --on
 
 # Turn off a room identified by its name
-openhue set room -n Studio --off
+openhue set room Studio --off
 
 # Set brightness of a single room
 openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65
@@ -39,7 +39,7 @@ openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue
 )
 
 // NewCmdSetRoom returns initialized cobra.Command instance for the 'set room' sub command
-func NewCmdSetRoom(ctx *openhue.Context, setOpt *CmdSetOptions) *cobra.Command {
+func NewCmdSetRoom(ctx *openhue.Context) *cobra.Command {
 
 	f := CmdSetLightFlags{}
 
@@ -54,13 +54,7 @@ func NewCmdSetRoom(ctx *openhue.Context, setOpt *CmdSetOptions) *cobra.Command {
 			o, err := f.toSetLightOptions()
 			cobra.CheckErr(err)
 
-			var rooms []openhue.Room
-
-			if setOpt.Name {
-				rooms = openhue.FindRoomsByName(ctx.Home, args)
-			} else {
-				rooms = openhue.FindRoomsByIds(ctx.Home, args)
-			}
+			rooms := openhue.SearchRooms(ctx.Home, args)
 
 			if len(rooms) == 0 {
 				ctx.Io.ErrPrintln("no room(s) found for given ID(s)", args)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-//go:generate oapi-codegen --package=gen -generate=client,types -o ./openhue/gen/openhue.gen.go https://api.redocly.com/registry/bundle/openhue/openhue/v2/openapi.yaml?branch=main
+//go:generate make generate
 
 import (
 	"openhue-cli/cmd"

--- a/openhue/gen/openhue.gen.go
+++ b/openhue/gen/openhue.gen.go
@@ -492,11 +492,9 @@ const (
 type ActionGet struct {
 	// Action The action to be executed on recall
 	Action *struct {
-		Color *Color `json:"color,omitempty"`
-
-		// ColorTemperature color temperature in mirek or null when the light color is not in the ct spectrum
-		ColorTemperature *Mirek   `json:"color_temperature,omitempty"`
-		Dimming          *Dimming `json:"dimming,omitempty"`
+		Color            *Color            `json:"color,omitempty"`
+		ColorTemperature *ColorTemperature `json:"color_temperature,omitempty"`
+		Dimming          *Dimming          `json:"dimming,omitempty"`
 
 		// Effects Basic feature containing effect properties.
 		Effects *struct {
@@ -524,12 +522,13 @@ type ActionGet struct {
 type ActionPost struct {
 	// Action The action to be executed on recall
 	Action struct {
-		Color *Color `json:"color,omitempty"`
-
-		// ColorTemperature color temperature in mirek or null when the light color is not in the ct spectrum
-		ColorTemperature *Mirek   `json:"color_temperature,omitempty"`
-		Dimming          *Dimming `json:"dimming,omitempty"`
-		Dynamics         *struct {
+		Color            *Color `json:"color,omitempty"`
+		ColorTemperature *struct {
+			// Mirek color temperature in mirek or null when the light color is not in the ct spectrum
+			Mirek *Mirek `json:"mirek,omitempty"`
+		} `json:"color_temperature,omitempty"`
+		Dimming  *Dimming `json:"dimming,omitempty"`
+		Dynamics *struct {
 			// Duration Duration of a light transition or timed effects in ms.
 			Duration *int `json:"duration,omitempty"`
 		} `json:"dynamics,omitempty"`
@@ -1401,7 +1400,8 @@ type SceneGet struct {
 	Actions *[]ActionGet `json:"actions,omitempty"`
 
 	// AutoDynamic Indicates whether to automatically start the scene dynamically on active recall
-	AutoDynamic *bool `json:"auto_dynamic,omitempty"`
+	AutoDynamic *bool               `json:"auto_dynamic,omitempty"`
+	Group       *ResourceIdentifier `json:"group,omitempty"`
 
 	// Id Unique identifier representing a specific resource instance
 	Id *string `json:"id,omitempty"`

--- a/openhue/home_model.go
+++ b/openhue/home_model.go
@@ -18,6 +18,15 @@ type Resource struct {
 	ctx *hueHomeCtx
 }
 
+// matchesNameOrId returns true of the given parameter equals either the Resource Name or Id.
+// If the parameter is empty, true is returned.
+func (r *Resource) matchesNameOrId(nameOrId string) bool {
+	if len(nameOrId) == 0 {
+		return true
+	}
+	return r.Name == nameOrId || r.Id == nameOrId
+}
+
 //
 // Home
 //
@@ -36,6 +45,7 @@ type Home struct {
 type Room struct {
 	Resource
 	Devices []Device
+	Scenes  []Scene
 	HueData *gen.RoomGet
 
 	// Services
@@ -173,4 +183,13 @@ func (groupedLight *GroupedLight) Set(o *SetLightOptions) {
 
 	_, err := groupedLight.ctx.api.UpdateGroupedLight(context.Background(), groupedLight.Id, *request)
 	cobra.CheckErr(err)
+}
+
+//
+// Scene
+//
+
+type Scene struct {
+	Resource
+	HueData *gen.SceneGet
 }

--- a/openhue/home_service_test.go
+++ b/openhue/home_service_test.go
@@ -9,36 +9,36 @@ import (
 var home = mockHome()
 
 func TestFindAllLights(t *testing.T) {
-	lights := FindAllLights(home)
+	lights := SearchLights(home, "", []string{})
 	assert.Len(t, lights, 4, "Home should contain 4 lights")
 }
 
 func TestFindLightsByName(t *testing.T) {
-	lights := FindLightsByName(home, []string{"room1_light2"})
+	lights := SearchLights(home, "", []string{"room1_light2"})
 	assert.Len(t, lights, 1, "Home should contain 1 single light for this name")
-	assert.Empty(t, FindLightsByName(home, []string{"foo"}), "Home should not contain any light with name 'foo'")
+	assert.Empty(t, SearchLights(home, "", []string{"foo"}), "Home should not contain any light with name 'foo'")
 }
 
 func TestFindLightsByIds(t *testing.T) {
-	lights := FindLightsByIds(home, []string{"room1_light2", "room2_light1"})
+	lights := SearchLights(home, "", []string{"room1_light2", "room2_light1"})
 	assert.Len(t, lights, 2, "Home should contain 2 lights for this name")
 }
 
 func TestFindAllRooms(t *testing.T) {
-	rooms := FindAllRooms(home)
+	rooms := SearchRooms(home, []string{})
 	assert.Len(t, rooms, 2, "Home should contain 2 rooms")
 }
 
 func TestFindRoomsByName(t *testing.T) {
-	rooms := FindRoomsByName(home, []string{"room1"})
+	rooms := SearchRooms(home, []string{"room1"})
 	assert.Len(t, rooms, 1, "Home should contain 1 single room for this name")
-	assert.Empty(t, FindRoomsByName(home, []string{"foo"}), "Home should not contain any room with name 'foo'")
+	assert.Empty(t, SearchRooms(home, []string{"foo"}), "Home should not contain any room with name 'foo'")
 }
 
 func TestFindRoomById(t *testing.T) {
-	rooms := FindRoomsByIds(home, []string{"room2"})
+	rooms := SearchRooms(home, []string{"room2"})
 	assert.Len(t, rooms, 1, "Home should contain 1 single room for this name")
-	assert.Empty(t, FindRoomsByIds(home, []string{"foo"}), "Home should not contain any room with ID 'foo'")
+	assert.Empty(t, SearchRooms(home, []string{"foo"}), "Home should not contain any room with ID 'foo'")
 }
 
 //


### PR DESCRIPTION
```
openhue get scene -h
```
```
Displays all the scenes with their main information, including the room they belong to.

Usage:
  openhue get scene [sceneId] [flags]

Aliases:
  scene, scenes

Examples:

# List all scenes
openhue get scene

# List all scenes as JSON 
openhue get scene --json

# Filter scenes for a given room name
openhue get scenes --room "Living Room"

# Filter scenes for a given room ID
openhue get scenes -r 878a65d6-613b-4239-8b77-588b535bfb4a

# List multiple scenes using either the ID or the name of the scene
openhue get scenes "Palm Beach" Nebula 462e54d9-ec5d-4bf6-879d-ad34cb9a692e


Flags:
  -h, --help          help for scene
  -r, --room string   Filter scenes by room (name or ID)

Global Flags:
  -j, --json   Format output as JSON

```