### PR TITLE
New Get and Set scene commands

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -46,6 +46,7 @@ Retrieve information for any kind of resources exposed by your Hue Bridge: light
 }
 
 func RunGetAllResources(ctx *openhue.Context, typeFlag string, o *CmdGetOptions) {
+
 	resp, err := ctx.Api.GetResourcesWithResponse(context.Background())
 	cobra.CheckErr(err)
 	resources := *(*resp.JSON200).Data

--- a/cmd/get/get_scene.go
+++ b/cmd/get/get_scene.go
@@ -20,7 +20,7 @@ func NewCmdGetScene(ctx *openhue.Context, co *CmdGetOptions) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "scene [sceneId]",
+		Use:     "scene [sceneId|sceneName]",
 		Aliases: []string{"scenes"},
 		Short:   "Get scenes",
 		Long: `

--- a/cmd/get/get_scene.go
+++ b/cmd/get/get_scene.go
@@ -40,8 +40,7 @@ openhue get scenes --room "Living Room"
 openhue get scenes -r 878a65d6-613b-4239-8b77-588b535bfb4a
 
 # List multiple scenes using either the ID or the name of the scene
-openhue get scenes "Palm Beach" Nebula 462e54d9-ec5d-4bf6-879d-ad34cb9a692e
-`,
+openhue get scenes "Palm Beach" Nebula 462e54d9-ec5d-4bf6-879d-ad34cb9a692e`,
 		Args: cobra.MatchAll(cobra.RangeArgs(0, 100), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			o.RunGetSceneCmd(ctx, args)

--- a/cmd/get/get_scene_test.go
+++ b/cmd/get/get_scene_test.go
@@ -1,0 +1,49 @@
+package get
+
+import (
+	"github.com/stretchr/testify/assert"
+	"openhue-cli/openhue"
+	"openhue-cli/openhue/gen"
+	"testing"
+)
+
+func TestGetAllScenes(t *testing.T) {
+	mockCtx, _ := openhue.NewTestContext(NewFakeHome())
+	cmd := NewCmdGetScene(mockCtx, &CmdGetOptions{Json: true})
+	err := cmd.Execute()
+	assert.Nil(t, err)
+}
+
+func NewFakeHome() *openhue.Home {
+	return &openhue.Home{
+		Resource: openhue.Resource{
+			Id:     "home-01",
+			Name:   "Home",
+			Type:   openhue.HomeResourceType(gen.BridgeHomeGetTypeBridgeHome),
+			Parent: nil,
+		},
+		Rooms: []openhue.Room{
+			{
+				Resource: openhue.Resource{
+					Id:   "room-01",
+					Name: "Room 1",
+					Type: openhue.HomeResourceType(gen.ResourceGetTypeRoom),
+				},
+				Devices: nil,
+				Scenes: []openhue.Scene{
+					{
+						Resource: openhue.Resource{
+							Id:   "scene-01",
+							Name: "Soho",
+						},
+						HueData: &gen.SceneGet{},
+					},
+				},
+				GroupedLight: nil,
+				HueData:      &gen.RoomGet{},
+			},
+		},
+		Devices: []openhue.Device{},
+		HueData: &gen.BridgeHomeGet{},
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,8 +71,7 @@ func Execute(buildInfo *openhue.BuildInfo) {
 
 	// get the API Client
 	api := c.NewOpenHueClient()
-	ctx := openhue.NewContext(openhue.NewIOStreams(), buildInfo, api)
-	ctx.Config = &c
+	ctx := openhue.NewContext(openhue.NewIOStreams(), buildInfo, api, &c)
 
 	// create the root command
 	root := NewCmdOpenHue(ctx)

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -14,12 +14,13 @@ func NewCmdSet(ctx *openhue.Context) *cobra.Command {
 		Short:   "Set specific features on resources",
 		GroupID: "hue",
 		Long: `
-Set the values for a specific resource
+Set the values for specific resources.
 `,
 	}
 
 	cmd.AddCommand(NewCmdSetLight(ctx))
 	cmd.AddCommand(NewCmdSetRoom(ctx))
+	cmd.AddCommand(NewCmdSetScene(ctx))
 
 	return cmd
 }

--- a/cmd/set/set_scene.go
+++ b/cmd/set/set_scene.go
@@ -1,0 +1,129 @@
+package set
+
+import (
+	"errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"openhue-cli/openhue"
+	"openhue-cli/openhue/gen"
+)
+
+const (
+	setSceneDocShort = "Activate a scene"
+	setSceneDocLong  = `
+This command allows the activate a scene using either a static or a dynamic palette.
+`
+	setSceneDocExample = `
+# Activate a scene
+openhue set scene Soho
+
+# Activate a scene by ID
+openhue set scene 62af7df3-d390-4408-a7ac-4b6b8805531b
+
+# Activate a scene in a specific room
+openhue set scene Soho -r Studio
+
+# Activate a scene with a dynamic palette
+openhue set scene Soho -a dynamic`
+)
+
+type CmdSetSceneOptions struct {
+	action actionEnum
+	room   string
+}
+
+// NewCmdSetScene returns initialized cobra.Command instance for the 'set scene' sub command
+func NewCmdSetScene(ctx *openhue.Context) *cobra.Command {
+
+	o := &CmdSetSceneOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "scene [sceneId|sceneName]",
+		Aliases: []string{"scenes"},
+		Short:   setSceneDocShort,
+		Long:    setSceneDocLong,
+		Example: setSceneDocExample,
+		Args:    cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Run: func(cmd *cobra.Command, args []string) {
+
+			scenes := openhue.SearchScenes(ctx.Home, o.room, args)
+
+			if len(scenes) == 0 {
+				ctx.Io.ErrPrintf("Scene '%s' not found%s\n", args[0], o.roomMsg())
+				return
+			}
+
+			for _, scene := range scenes {
+				err := scene.Activate(o.action.toSceneRecallAction())
+				if err != nil {
+					ctx.Io.ErrPrintln(err.Error())
+					continue
+				}
+				ctx.Io.Printf("Scene '%s' activated%s\n", scene.Name, o.roomMsg())
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.room, "room", "r", "", "room where the scene is located (in case multiple scenes with the same name exist)")
+
+	// action flag
+	cmd.Flags().VarP(&o.action, "action", "a", "action to perform on the scene. allowed: active (default), dynamic or static")
+	_ = cmd.RegisterFlagCompletionFunc("action", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			"active\tthe actions in the scene are executed on the target",
+			"static\t(default)",
+			"dynamic\tstarts dynamic scene with colors in the Palette object",
+		}, cobra.ShellCompDirectiveDefault
+	})
+
+	return cmd
+}
+
+type actionEnum string
+
+const (
+	active  actionEnum = "active"
+	static  actionEnum = "static"
+	dynamic actionEnum = "dynamic"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *actionEnum) String() string {
+	return string(*e)
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (e *actionEnum) Set(v string) error {
+	switch v {
+	case "active", "static", "dynamic":
+		*e = actionEnum(v)
+		return nil
+	default:
+		return errors.New(`must be one of "active", "static", or "dynamic"`)
+	}
+}
+
+// Type is only used in help text
+func (e *actionEnum) Type() string {
+	return "string"
+}
+
+func (e *actionEnum) toSceneRecallAction() gen.SceneRecallAction {
+
+	if len(string(*e)) == 0 {
+		log.Info("action flag not set, defaulting to 'active")
+		*e = "active"
+	}
+
+	if *e == dynamic {
+		return gen.SceneRecallActionDynamicPalette
+	}
+	return gen.SceneRecallAction(e.String())
+}
+
+func (o *CmdSetSceneOptions) roomMsg() string {
+	if o.room != "" {
+		return " in room '" + o.room + "'"
+	}
+	return ""
+}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestNewCmdVersion(t *testing.T) {
 
-	ctx, out := openhue.NewTestContextWithoutApi()
+	ctx, out := openhue.NewTestContext(nil)
 
 	cmd := NewCmdVersion(ctx)
 	err := cmd.Execute()

--- a/openhue/context.go
+++ b/openhue/context.go
@@ -15,16 +15,21 @@ type Context struct {
 }
 
 // NewContext returns an initialized Context from a given gen.ClientWithResponses API with default IOStreams
-func NewContext(io IOStreams, buildInfo *BuildInfo, api *gen.ClientWithResponses) *Context {
+func NewContext(io IOStreams, buildInfo *BuildInfo, api *gen.ClientWithResponses, config *Config) *Context {
 	return &Context{
 		Io:        io,
 		BuildInfo: buildInfo,
 		Api:       api,
+		Config:    config,
 	}
 }
 
-func NewTestContextWithoutApi() (*Context, *bytes.Buffer) {
+// NewTestContext returns a Context for testing usage only and the out buffer to validate
+// the command output.
+// The Api field of the returned Context is not set.
+func NewTestContext(home *Home) (*Context, *bytes.Buffer) {
 	streams, _, out, _ := NewTestIOStreams()
-	ctx := NewContext(streams, NewTestBuildInfo(), nil)
+	ctx := NewContext(streams, NewTestBuildInfo(), nil, nil)
+	ctx.Home = home
 	return ctx, out
 }

--- a/openhue/context_test.go
+++ b/openhue/context_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestNewContext(t *testing.T) {
-	ctx := NewContext(NewTestIOStreamsDiscard(), NewTestBuildInfo(), &gen.ClientWithResponses{})
+	ctx := NewContext(NewTestIOStreamsDiscard(), NewTestBuildInfo(), &gen.ClientWithResponses{}, nil)
 	assert.NotNil(t, ctx, "Context should not be nil")
 }
 
 func TestNewTestContextWithoutApi(t *testing.T) {
-	ctx, out := NewTestContextWithoutApi()
+	ctx, out := NewTestContext(nil)
 	assert.NotNil(t, ctx, "Context should not be nil")
 	assert.NotNil(t, out, "Out buffer should not be nil")
 }

--- a/openhue/gen/openhue.gen.go
+++ b/openhue/gen/openhue.gen.go
@@ -425,16 +425,16 @@ const (
 	ScenePostTypeScene ScenePostType = "scene"
 )
 
-// Defines values for ScenePutRecallAction.
-const (
-	ScenePutRecallActionActive         ScenePutRecallAction = "active"
-	ScenePutRecallActionDynamicPalette ScenePutRecallAction = "dynamic_palette"
-	ScenePutRecallActionStatic         ScenePutRecallAction = "static"
-)
-
 // Defines values for ScenePutType.
 const (
 	Scene ScenePutType = "scene"
+)
+
+// Defines values for SceneRecallAction.
+const (
+	SceneRecallActionActive         SceneRecallAction = "active"
+	SceneRecallActionDynamicPalette SceneRecallAction = "dynamic_palette"
+	SceneRecallActionStatic         SceneRecallAction = "static"
 )
 
 // Defines values for SignalingSignal.
@@ -634,15 +634,6 @@ type ColorTemperatureDelta struct {
 
 // ColorTemperatureDeltaAction defines model for ColorTemperatureDelta.Action.
 type ColorTemperatureDeltaAction string
-
-// ColorTemperaturePaletteGet defines model for ColorTemperaturePaletteGet.
-type ColorTemperaturePaletteGet struct {
-	ColorTemperature *struct {
-		// Mirek color temperature in mirek or null when the light color is not in the ct spectrum
-		Mirek *Mirek `json:"mirek,omitempty"`
-	} `json:"color_temperature,omitempty"`
-	Dimming *Dimming `json:"dimming,omitempty"`
-}
 
 // ColorTemperaturePalettePost defines model for ColorTemperaturePalettePost.
 type ColorTemperaturePalettePost struct {
@@ -1407,26 +1398,12 @@ type SceneGet struct {
 	Id *string `json:"id,omitempty"`
 
 	// IdV1 Clip v1 resource identifier
-	IdV1     *string `json:"id_v1,omitempty"`
-	Metadata *struct {
-		// Appdata Application specific data. Free format string.
-		Appdata *string             `json:"appdata,omitempty"`
-		Image   *ResourceIdentifier `json:"image,omitempty"`
-
-		// Name Human readable name of a resource
-		Name *string `json:"name,omitempty"`
-	} `json:"metadata,omitempty"`
-	Owner *ResourceIdentifier `json:"owner,omitempty"`
+	IdV1     *string             `json:"id_v1,omitempty"`
+	Metadata *SceneMetadata      `json:"metadata,omitempty"`
+	Owner    *ResourceIdentifier `json:"owner,omitempty"`
 
 	// Palette Group of colors that describe the palette of colors to be used when playing dynamics
-	Palette *struct {
-		Color            *[]ColorPaletteGet            `json:"color,omitempty"`
-		ColorTemperature *[]ColorTemperaturePaletteGet `json:"color_temperature,omitempty"`
-		Dimming          *[]Dimming                    `json:"dimming,omitempty"`
-		Effects          *[]struct {
-			Effect *SupportedEffects `json:"effect,omitempty"`
-		} `json:"effects,omitempty"`
-	} `json:"palette,omitempty"`
+	Palette *ScenePalette `json:"palette,omitempty"`
 
 	// Speed Speed of dynamic palette for this scene
 	Speed  *float32 `json:"speed,omitempty"`
@@ -1442,6 +1419,26 @@ type SceneGetStatusActive string
 // SceneGetType defines model for SceneGet.Type.
 type SceneGetType string
 
+// SceneMetadata defines model for SceneMetadata.
+type SceneMetadata struct {
+	// Appdata Application specific data. Free format string.
+	Appdata *string             `json:"appdata,omitempty"`
+	Image   *ResourceIdentifier `json:"image,omitempty"`
+
+	// Name Human readable name of a resource
+	Name *string `json:"name,omitempty"`
+}
+
+// ScenePalette Group of colors that describe the palette of colors to be used when playing dynamics
+type ScenePalette struct {
+	Color            *[]ColorPaletteGet             `json:"color,omitempty"`
+	ColorTemperature *[]ColorTemperaturePalettePost `json:"color_temperature,omitempty"`
+	Dimming          *[]Dimming                     `json:"dimming,omitempty"`
+	Effects          *[]struct {
+		Effect *SupportedEffects `json:"effect,omitempty"`
+	} `json:"effects,omitempty"`
+}
+
 // ScenePost defines model for ScenePost.
 type ScenePost struct {
 	// Actions List of actions to be executed synchronously on recall
@@ -1450,24 +1447,10 @@ type ScenePost struct {
 	// AutoDynamic Indicates whether to automatically start the scene dynamically on active recall
 	AutoDynamic *bool              `json:"auto_dynamic,omitempty"`
 	Group       ResourceIdentifier `json:"group"`
-	Metadata    struct {
-		// Appdata Application specific data. Free format string.
-		Appdata *string             `json:"appdata,omitempty"`
-		Image   *ResourceIdentifier `json:"image,omitempty"`
-
-		// Name Human readable name of a resource
-		Name *string `json:"name,omitempty"`
-	} `json:"metadata"`
+	Metadata    SceneMetadata      `json:"metadata"`
 
 	// Palette Group of colors that describe the palette of colors to be used when playing dynamics
-	Palette *struct {
-		Color            *[]ColorPaletteGet             `json:"color,omitempty"`
-		ColorTemperature *[]ColorTemperaturePalettePost `json:"color_temperature,omitempty"`
-		Dimming          *[]Dimming                     `json:"dimming,omitempty"`
-		Effects          *[]struct {
-			Effect *SupportedEffects `json:"effect,omitempty"`
-		} `json:"effects,omitempty"`
-	} `json:"palette,omitempty"`
+	Palette *ScenePalette `json:"palette,omitempty"`
 
 	// Speed Speed of dynamic palette for this scene
 	Speed *float32       `json:"speed,omitempty"`
@@ -1480,47 +1463,36 @@ type ScenePostType string
 // ScenePut defines model for ScenePut.
 type ScenePut struct {
 	// Actions List of actions to be executed synchronously on recall
-	Actions []ActionPost `json:"actions"`
+	Actions *[]ActionPost `json:"actions,omitempty"`
 
 	// AutoDynamic Indicates whether to automatically start the scene dynamically on active recall
-	AutoDynamic *bool `json:"auto_dynamic,omitempty"`
-	Metadata    struct {
-		// Appdata Application specific data. Free format string.
-		Appdata *string             `json:"appdata,omitempty"`
-		Image   *ResourceIdentifier `json:"image,omitempty"`
-
-		// Name Human readable name of a resource
-		Name *string `json:"name,omitempty"`
-	} `json:"metadata"`
+	AutoDynamic *bool          `json:"auto_dynamic,omitempty"`
+	Metadata    *SceneMetadata `json:"metadata,omitempty"`
 
 	// Palette Group of colors that describe the palette of colors to be used when playing dynamics
-	Palette *struct {
-		Color            *[]ColorPaletteGet             `json:"color,omitempty"`
-		ColorTemperature *[]ColorTemperaturePalettePost `json:"color_temperature,omitempty"`
-		Dimming          *[]Dimming                     `json:"dimming,omitempty"`
-		Effects          *[]struct {
-			Effect *SupportedEffects `json:"effect,omitempty"`
-		} `json:"effects,omitempty"`
-	} `json:"palette,omitempty"`
-	Recall *struct {
-		// Action When writing active, the actions in the scene are executed on the target. dynamic_palette starts dynamic scene with colors in the Palette object.
-		Action  *ScenePutRecallAction `json:"action,omitempty"`
-		Dimming *Dimming              `json:"dimming,omitempty"`
-
-		// Duration Transition to the scene within the timeframe given by duration
-		Duration *int `json:"duration,omitempty"`
-	} `json:"recall,omitempty"`
+	Palette *ScenePalette `json:"palette,omitempty"`
+	Recall  *SceneRecall  `json:"recall,omitempty"`
 
 	// Speed Speed of dynamic palette for this scene
 	Speed *float32      `json:"speed,omitempty"`
 	Type  *ScenePutType `json:"type,omitempty"`
 }
 
-// ScenePutRecallAction When writing active, the actions in the scene are executed on the target. dynamic_palette starts dynamic scene with colors in the Palette object.
-type ScenePutRecallAction string
-
 // ScenePutType defines model for ScenePut.Type.
 type ScenePutType string
+
+// SceneRecall defines model for SceneRecall.
+type SceneRecall struct {
+	// Action When writing active, the actions in the scene are executed on the target. dynamic_palette starts dynamic scene with colors in the Palette object.
+	Action  *SceneRecallAction `json:"action,omitempty"`
+	Dimming *Dimming           `json:"dimming,omitempty"`
+
+	// Duration Transition to the scene within the timeframe given by duration
+	Duration *int `json:"duration,omitempty"`
+}
+
+// SceneRecallAction When writing active, the actions in the scene are executed on the target. dynamic_palette starts dynamic scene with colors in the Palette object.
+type SceneRecallAction string
 
 // Signaling Feature containing signaling properties.
 type Signaling struct {


### PR DESCRIPTION
This PR introduces 2 new scenes' related commands: 
- the `openhue get scene` command that allows listing the available scenes
- the `openhue set scene` command that allows activating a scene

### `openhue get scene`
```
Displays all the scenes with their main information, including the room they belong to.

Usage:
  openhue get scene [sceneId|sceneName] [flags]

Aliases:
  scene, scenes

Examples:

# List all scenes
openhue get scene

# List all scenes as JSON 
openhue get scene --json

# Filter scenes for a given room name
openhue get scenes --room "Living Room"

# Filter scenes for a given room ID
openhue get scenes -r 878a65d6-613b-4239-8b77-588b535bfb4a

# List multiple scenes using either the ID or the name of the scene
openhue get scenes "Palm Beach" Nebula 462e54d9-ec5d-4bf6-879d-ad34cb9a692e

Flags:
  -h, --help          help for scene
  -r, --room string   Filter scenes by room (name or ID)

Global Flags:
  -j, --json   Format output as JSON
```

### `openhue set scene`
```
This command allows the activate a scene using either a static or a dynamic palette.

Usage:
  openhue set scene [sceneId|sceneName] [flags]

Aliases:
  scene, scenes

Examples:

# Activate a scene
openhue set scene Soho

# Activate a scene by ID
openhue set scene 62af7df3-d390-4408-a7ac-4b6b8805531b

# Activate a scene in a specific room
openhue set scene Soho -r Studio

# Activate a scene with a dynamic palette
openhue set scene Soho -a dynamic

Flags:
  -a, --action string   action to perform on the scene. allowed: active (default), dynamic or static
  -h, --help            help for scene
  -r, --room string     room where the scene is located (in case multiple scenes with the same name exist)
```