### PR TITLE
#56 GoReleaser is now documented as a required tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "make \033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: generate
-generate: ## Generates the openhue/gen/openhue.gen.go client. Usage: make generate [spec=/path/to/openhue.yaml]
+generate: _check-oapi-codegen-installation ## Generates the openhue/gen/openhue.gen.go client. Usage: make generate [spec=/path/to/openhue.yaml]
 ifdef spec
 	@echo "Code generation from $(spec)"
 	@oapi-codegen --package=gen -generate=client,types -o ./openhue/gen/openhue.gen.go "$(spec)"
@@ -26,7 +26,7 @@ endif
 	@echo "\n${GREEN}${BOLD}./openhue/openhue.gen.go successfully generated 🚀${RESET}"
 
 .PHONY: build
-build: ## Generates the openhue-cli executables in the ./dist folder
+build: _check-goreleaser-installation ## Generates the openhue-cli executables in the ./dist folder
 	@$(GORELEASER) check
 	@$(GORELEASER) build --clean --snapshot --single-target
 	@echo "\n${GREEN}${BOLD}openhue binaries successfully generated in the ./dist folder 📦${RESET}"
@@ -58,3 +58,15 @@ clean: ##
 	@rm -f coverage.html
 	@$(GO) clean
 	@echo "\n${GREEN}${BOLD}Project successfully cleaned 🧹${RESET} (removed ./dist folder + go clean)"
+
+#
+# Private targets
+#
+
+.PHONY: _check-goreleaser-installation
+_check-goreleaser-installation:
+	@command -v goreleaser >/dev/null 2>&1 || { echo >&2 "GoReleaser is not installed (https://goreleaser.com/install)"; exit 1; }
+
+.PHONY: _check-oapi-codegen-installation
+_check-oapi-codegen-installation:
+	@command -v oapi-codegen >/dev/null 2>&1 || { echo >&2 "oapi-codegen is not installed (https://github.com/oapi-codegen/oapi-codegen)"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To begin developing with Open-Hue's OpenAPI specification, follow these steps:
 
 Before you start, ensure that you have the following prerequisites installed:
 - [Golang](https://go.dev/doc/install) that is used to build and run the project
-- [GoReleaser](https://goreleaser.com) (_optional_) that is used to build and release the binaries
+- [GoReleaser](https://goreleaser.com) that is used to build and release the binaries. Used behind the scene when running the `make build` command
 - [Docker](https://docs.docker.com/engine/install/) (_optional_) that is used to build the CLI Docker Image and run it as a container
 
 ### Fork the Repository

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To begin developing with Open-Hue's OpenAPI specification, follow these steps:
 Before you start, ensure that you have the following prerequisites installed:
 - [Golang](https://go.dev/doc/install) that is used to build and run the project
 - [GoReleaser](https://goreleaser.com) that is used to build and release the binaries. Used behind the scene when running the `make build` command
+- [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) (_optional_) that is used to generate the client code from the openhue-api specification. Used behind the scene when running the `make generate` command
 - [Docker](https://docs.docker.com/engine/install/) (_optional_) that is used to build the CLI Docker Image and run it as a container
 
 ### Fork the Repository


### PR DESCRIPTION
If GoReleaser hasn´t been installed, the `make build` command will produce the following error message: 
```
make build
GoReleaser is not installed (https://goreleaser.com/install)
make: *** [Makefile:68: _check-goreleaser-installation] Error 1
``` 

Fixes #56