### PR TITLE
If set, use the $XDG_CONFIG_HOME env var is set to locate the openhue config directory @coderabbitai

### DIFF
--- a/openhue/config.go
+++ b/openhue/config.go
@@ -20,11 +20,18 @@ var CommandsWithNoConfig = []string{"setup", "config", "help", "discover", "auth
 var configPath string
 
 func init() {
-	// Find home directory.
-	home, err := os.UserHomeDir()
-	cobra.CheckErr(err)
 
-	configPath = filepath.Join(home, "/.openhue")
+	// If the $XDG_CONFIG_HOME env var is set, use it instead of the home user home dir
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if len(xdgConfigHome) > 0 {
+		configPath = filepath.Join(xdgConfigHome, "/openhue")
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+		configPath = filepath.Join(home, "/.openhue")
+	}
+
 	_ = os.MkdirAll(configPath, os.ModePerm)
 }
 

--- a/openhue/config.go
+++ b/openhue/config.go
@@ -24,12 +24,12 @@ func init() {
 	// If the $XDG_CONFIG_HOME env var is set, use it instead of the home user home dir
 	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 	if len(xdgConfigHome) > 0 {
-		configPath = filepath.Join(xdgConfigHome, "/openhue")
+		configPath = filepath.Join(xdgConfigHome, "openhue")
 	} else {
 		// Find home directory.
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
-		configPath = filepath.Join(home, "/.openhue")
+		configPath = filepath.Join(home, ".openhue")
 	}
 
 	_ = os.MkdirAll(configPath, os.ModePerm)


### PR DESCRIPTION
Fixes #66 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Configuration directory now follows the XDG Base Directory Specification, using the `XDG_CONFIG_HOME` environment variable if set. This enhances compatibility with standard Linux and Unix configuration management practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->