### PR TITLE
Add --transition-time flag for lights and rooms

### DIFF
--- a/cmd/set/common.go
+++ b/cmd/set/common.go
@@ -2,9 +2,11 @@ package set
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
 	"openhue-cli/util/color"
+	"time"
+
+	"github.com/spf13/cobra"
 )
 
 //
@@ -12,14 +14,15 @@ import (
 //
 
 type CmdSetLightFlags struct {
-	On          bool
-	Off         bool
-	Brightness  float32
-	Rgb         string
-	X           float32
-	Y           float32
-	ColorName   string
-	Temperature int
+	On             bool
+	Off            bool
+	Brightness     float32
+	Rgb            string
+	X              float32
+	Y              float32
+	ColorName      string
+	Temperature    int
+	TransitionTime string
 }
 
 func (flags *CmdSetLightFlags) initCmd(cmd *cobra.Command) {
@@ -51,6 +54,9 @@ func (flags *CmdSetLightFlags) initCmd(cmd *cobra.Command) {
 
 	// temperature
 	cmd.Flags().IntVarP(&flags.Temperature, "temperature", "t", -1, "Color temperature in Mirek [min=153, max=500]")
+
+	// transition time
+	cmd.Flags().StringVar(&flags.TransitionTime, "transition-time", "0s", "Duration of a light transition")
 
 	// exclusions
 	cmd.MarkFlagsMutuallyExclusive("color", "rgb", "cie-x", "temperature")
@@ -108,6 +114,12 @@ func (flags *CmdSetLightFlags) toSetLightOptions() (*openhue.SetLightOptions, er
 			X: c.X,
 			Y: c.Y,
 		}
+	}
+
+	if flags.TransitionTime != "0s" {
+		duration, err := time.ParseDuration(flags.TransitionTime)
+		cobra.CheckErr(err)
+		o.TransitionTime = int(duration.Milliseconds())
 	}
 
 	return o, nil

--- a/cmd/set/common.go
+++ b/cmd/set/common.go
@@ -119,7 +119,7 @@ func (flags *CmdSetLightFlags) toSetLightOptions() (*openhue.SetLightOptions, er
 	if flags.TransitionTime != "0s" {
 		duration, err := time.ParseDuration(flags.TransitionTime)
 		cobra.CheckErr(err)
-		o.TransitionTime = int(duration.Milliseconds())
+		o.TransitionTime = duration
 	}
 
 	return o, nil

--- a/cmd/set/set_light.go
+++ b/cmd/set/set_light.go
@@ -1,9 +1,10 @@
 package set
 
 import (
+	"openhue-cli/openhue"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"openhue-cli/openhue"
 )
 
 const (
@@ -39,6 +40,9 @@ openhue set light 15f51223-1e83-4e48-9158-0c20dbd5734e --on --color powder_blue
 
 # Set color temperature (in Mirek) of a single light
 openhue set light MyLight --on -t 250
+
+# Set transition time when changing brightness of a light
+openhue set light office1 --on --brightness 75 --transition-time 30s
 `
 )
 

--- a/cmd/set/set_room.go
+++ b/cmd/set/set_room.go
@@ -1,8 +1,9 @@
 package set
 
 import (
-	"github.com/spf13/cobra"
 	"openhue-cli/openhue"
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -24,8 +25,8 @@ openhue set room 83111103-a3eb-40c5-b22a-02deedd21fcb 8f0a7b52-df25-4bc7-b94d-0d
 # Turn off a room identified by its name
 openhue set room Studio --off
 
-# Set brightness of a single room
-openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65
+# Set brightness of a single room with transition time
+openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --brightness 42.65 --transition-time 5s
 
 # Set color (in RGB) of a single room
 openhue set room 15f51223-1e83-4e48-9158-0c20dbd5734e --on --rgb #3399FF

--- a/openhue/home_model.go
+++ b/openhue/home_model.go
@@ -2,6 +2,7 @@ package openhue
 
 import (
 	"openhue-cli/util/color"
+	"time"
 
 	"github.com/openhue/openhue-go"
 	"github.com/spf13/cobra"
@@ -73,7 +74,7 @@ type SetLightOptions struct {
 	Brightness     float32
 	Color          color.XY
 	Temperature    int
-	TransitionTime int
+	TransitionTime time.Duration
 }
 
 func NewSetLightOptions() *SetLightOptions {
@@ -153,8 +154,9 @@ func (light *Light) Set(o *SetLightOptions) {
 	}
 
 	if o.TransitionTime > 0 {
+		duration := int(o.TransitionTime.Milliseconds())
 		request.Dynamics = &openhue.LightDynamics{
-			Duration: &o.TransitionTime,
+			Duration: &duration,
 		}
 	}
 
@@ -203,8 +205,9 @@ func (groupedLight *GroupedLight) Set(o *SetLightOptions) {
 	}
 
 	if o.TransitionTime > 0 {
+		duration := int(o.TransitionTime.Milliseconds())
 		request.Dynamics = &openhue.Dynamics{
-			Duration: &o.TransitionTime,
+			Duration: &duration,
 		}
 	}
 

--- a/openhue/home_model.go
+++ b/openhue/home_model.go
@@ -202,6 +202,12 @@ func (groupedLight *GroupedLight) Set(o *SetLightOptions) {
 		}
 	}
 
+	if o.TransitionTime > 0 {
+		request.Dynamics = &openhue.Dynamics{
+			Duration: &o.TransitionTime,
+		}
+	}
+
 	err := groupedLight.ctx.h.UpdateGroupedLight(groupedLight.Id, *request)
 	cobra.CheckErr(err)
 }

--- a/openhue/home_model.go
+++ b/openhue/home_model.go
@@ -1,9 +1,10 @@
 package openhue
 
 import (
+	"openhue-cli/util/color"
+
 	"github.com/openhue/openhue-go"
 	"github.com/spf13/cobra"
-	"openhue-cli/util/color"
 )
 
 type HomeResourceType openhue.ResourceIdentifierRtype
@@ -68,10 +69,11 @@ type Device struct {
 //
 
 type SetLightOptions struct {
-	Status      LightStatus
-	Brightness  float32
-	Color       color.XY
-	Temperature int
+	Status         LightStatus
+	Brightness     float32
+	Color          color.XY
+	Temperature    int
+	TransitionTime int
 }
 
 func NewSetLightOptions() *SetLightOptions {
@@ -147,6 +149,12 @@ func (light *Light) Set(o *SetLightOptions) {
 				X: &o.Color.X,
 				Y: &o.Color.Y,
 			},
+		}
+	}
+
+	if o.TransitionTime > 0 {
+		request.Dynamics = &openhue.LightDynamics{
+			Duration: &o.TransitionTime,
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces a new `--transition-time` flag to the `set light` and `set room` commands, allowing users to specify a duration for state changes like brightness or color. This enables smooth, gradual transitions instead of abrupt changes.

### Motivation

Previously, all light and room state changes were instantaneous. While functional, this lacked the finesse required for creating more pleasant ambiances or advanced lighting effects. By adding a **transition time**, users can now create smoother, more professional-looking lighting automations (e.g., a slow fade-in or a gentle color shift).

-----

### Description of Changes

  * **Shared Flag Logic (`cmd/set/common.go`):**
      * A `--transition-time` string flag was added to the common `CmdSetLightFlags` struct, making it available to both `set light` and `set room`.
      * The `toSetLightOptions` function was updated to parse the duration string (e.g., `"5s"`, `"1m30s"`) into milliseconds using `time.ParseDuration`.
  * **API Model (`openhue/home_model.go`):**
      * The `SetLightOptions` struct now includes a `TransitionTime` field.
      * The `Light.Set()` and `GroupedLight.Set()` methods were updated to include the `dynamics` property with the specified duration in the API request body sent to the Hue Bridge.
  * **Command Updates (`cmd/set/set_light.go`, `cmd/set/set_room.go`):**
      * The command-line examples for both `set light` and `set room` have been updated to demonstrate the usage of the new `--transition-time` flag.

-----

### How to Verify

You can test the new functionality by running commands with the `--transition-time` flag.

1.  Clone the branch and build the CLI.
2.  Run the `set light` or `set room` command with a transition time.

<!-- end list -->

```shell
# Example: Slowly dim a light over 10 seconds
openhue set light "My Desk Lamp" --on --brightness 50 --transition-time 10s

# Example: Change the color of a room over 30 seconds
openhue set room "Living Room" --on --color blue --transition-time 30s
```

3.  Confirm that the lights execute the change over the specified duration rather than instantly. Existing commands without the flag should continue to work as before.

Fixes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a transition time when changing light or room settings using the `--transition-time` flag.
  * Transition time can now be set for smoother light state changes.

* **Documentation**
  * Updated command-line usage examples to demonstrate the new `--transition-time` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->