### PR TITLE
Prevent panic when listing rooms with no lights

### DIFF
--- a/openhue/home_model.go
+++ b/openhue/home_model.go
@@ -171,6 +171,10 @@ type GroupedLight struct {
 }
 
 func (groupedLight *GroupedLight) IsOn() bool {
+	// A room may not have any light, in this case the GroupedLight service is nil.
+	if groupedLight == nil || groupedLight.HueData == nil || groupedLight.HueData.On == nil || groupedLight.HueData.On.On == nil {
+		return false
+	}
 	return *groupedLight.HueData.On.On
 }
 


### PR DESCRIPTION
The `openhue get room` command would cause a panic (`nil` pointer dereference) if a room configured on the Hue Bridge had no lights assigned to it.

This was because the `(*GroupedLight).IsOn()` method did not safely handle cases where the `GroupedLight` service was `nil`. When iterating through rooms, the method would be called on these "empty" rooms, leading to a crash.

This commit adds a nil check at the beginning of the `IsOn()` method. If the `GroupedLight` instance or its nested `On` property is nil, the method now safely returns `false`, preventing the panic and ensuring that empty rooms are handled gracefully.

Fixes https://github.com/openhue/openhue-cli/issues/77