### PR TITLE
add terminal display to ease parsing for command line

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -8,7 +8,8 @@ import (
 )
 
 type CmdGetOptions struct {
-	Json bool
+	Json     bool
+	Terminal bool
 }
 
 // NewCmdGet returns an initialized Command instance for 'get' sub command
@@ -34,6 +35,7 @@ Retrieve information for any kind of resources exposed by your Hue Bridge: light
 
 	// persistence flags
 	cmd.PersistentFlags().BoolVarP(&o.Json, "json", "j", false, "Format output as JSON")
+	cmd.PersistentFlags().BoolVarP(&o.Terminal, "terminal", "c", false, "Format from Terminal use")
 
 	// sub commands
 	cmd.AddCommand(NewCmdGetEvents(ctx, &o))

--- a/cmd/get/get_light.go
+++ b/cmd/get/get_light.go
@@ -64,6 +64,8 @@ func (o *LightOptions) RunGetLightCmd(ctx *openhue.Context, args []string) {
 
 	if o.Json {
 		util.PrintJsonArray(ctx.Io, lights)
+	} else if o.Terminal {
+		util.PrintTerminal(ctx.Io, lights, PrintLight)
 	} else {
 		util.PrintTable(ctx.Io, lights, PrintLight, "ID", "Name", "Type", "Status", "Brightness", "Room")
 	}

--- a/util/utils.go
+++ b/util/utils.go
@@ -44,3 +44,9 @@ func PrintTable[T any](io openhue.IOStreams, table []T, lineFn func(T) string, h
 
 	_ = w.Flush()
 }
+
+func PrintTerminal[T any](io openhue.IOStreams, table []T, lineFn func(T) string) {
+	for _, l := range table {
+		io.Println(lineFn(l))
+	}
+}


### PR DESCRIPTION
Print without header and blank line to ease parsing with cli tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--terminal` (short `-c`) flag to the get command, providing a terminal-friendly output format option alongside the existing JSON format for displaying light information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->