### PR TITLE
feat: add shell completion commands

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,18 @@ brews:
     homepage: https://github.com/openhue/homebrew-cli
     description: OpenHue CLI is a command-line interface for interacting with Philips Hue smart lighting systems
     license: Apache License 2.0
+    caveats: |
+      To enable shell completions for your current shell session, run:
+        #{case File.basename(ENV["SHELL"].to_s)
+          when "bash"
+            "source <(openhue completion bash)"
+          when "zsh"
+            "source <(openhue completion zsh)"
+          when "fish"
+            "openhue completion fish | source"
+          else
+            "openhue completion setup"
+          end}
     repository:
       owner: openhue
       name: homebrew-cli

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -97,7 +97,8 @@ func printSetupCommand(out io.Writer, shell string) error {
 }
 
 func setupCommandForShell(shell string) (string, error) {
-	switch filepath.Base(shell) {
+	base := filepath.Base(shell)
+	switch base {
 	case "bash":
 		return "source <(openhue completion bash)", nil
 	case "zsh":
@@ -105,7 +106,7 @@ func setupCommandForShell(shell string) (string, error) {
 	case "fish":
 		return "openhue completion fish | source", nil
 	default:
-		return "", fmt.Errorf("unsupported shell %q; supported shells are bash, zsh, and fish", shell)
+		return "", fmt.Errorf("unsupported shell %q; supported shells are bash, zsh, and fish", base)
 	}
 }
 

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -1,0 +1,114 @@
+package completion
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"openhue-cli/openhue"
+)
+
+type shellProvider func() string
+
+// NewCmdCompletion creates the command tree for generating shell completions.
+func NewCmdCompletion(io openhue.IOStreams) *cobra.Command {
+	return newCmdCompletion(io.Out, currentShell)
+}
+
+func newCmdCompletion(out io.Writer, getShell shellProvider) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "completion",
+		GroupID:       "config",
+		Short:         "Generate shell completion scripts",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Long: `
+Generate shell completion scripts for openhue.
+
+Use one of the shell-specific subcommands to print a completion script, or use
+the setup subcommand to print the command for enabling completions in your
+current shell session.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printSetupCommand(out, getShell())
+		},
+	}
+
+	cmd.AddCommand(newCmdCompletionBash(out))
+	cmd.AddCommand(newCmdCompletionZsh(out))
+	cmd.AddCommand(newCmdCompletionFish(out))
+	cmd.AddCommand(newCmdCompletionSetup(out, getShell))
+
+	return cmd
+}
+
+func newCmdCompletionBash(out io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "bash",
+		Short: "Generate the bash completion script",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenBashCompletionV2(out, true)
+		},
+	}
+}
+
+func newCmdCompletionZsh(out io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "zsh",
+		Short: "Generate the zsh completion script",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenZshCompletion(out)
+		},
+	}
+}
+
+func newCmdCompletionFish(out io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "fish",
+		Short: "Generate the fish completion script",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenFishCompletion(out, true)
+		},
+	}
+}
+
+func newCmdCompletionSetup(out io.Writer, getShell shellProvider) *cobra.Command {
+	return &cobra.Command{
+		Use:           "setup",
+		Short:         "Print the command to enable completions for your shell",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printSetupCommand(out, getShell())
+		},
+	}
+}
+
+func printSetupCommand(out io.Writer, shell string) error {
+	command, err := setupCommandForShell(shell)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(out, "Run this command to enable openhue completions for your current shell session:\n\n  %s\n", command)
+	return err
+}
+
+func setupCommandForShell(shell string) (string, error) {
+	switch filepath.Base(shell) {
+	case "bash":
+		return "source <(openhue completion bash)", nil
+	case "zsh":
+		return "source <(openhue completion zsh)", nil
+	case "fish":
+		return "openhue completion fish | source", nil
+	default:
+		return "", fmt.Errorf("unsupported shell %q; supported shells are bash, zsh, and fish", shell)
+	}
+}
+
+func currentShell() string {
+	return os.Getenv("SHELL")
+}

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -109,7 +109,7 @@ func TestCompletionSetupReturnsAnErrorForUnsupportedShell(t *testing.T) {
 	// Assert
 	require.Error(t, err)
 	assert.Empty(t, strings.TrimSpace(out.String()))
-	assert.Contains(t, err.Error(), "unsupported shell")
+	assert.Contains(t, err.Error(), `unsupported shell "tcsh"`)
 }
 
 func createTestContext(shell string) (*cobra.Command, *strings.Builder) {

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -1,0 +1,129 @@
+package completion
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionCommandsGenerateScripts(t *testing.T) {
+	tests := []struct {
+		name          string
+		shell         string
+		expectedLines []string
+	}{
+		{
+			name:  "bash",
+			shell: "bash",
+			expectedLines: []string{
+				"# bash completion V2 for openhue",
+				"__start_openhue",
+			},
+		},
+		{
+			name:  "zsh",
+			shell: "zsh",
+			expectedLines: []string{
+				"#compdef openhue",
+				"_openhue()",
+			},
+		},
+		{
+			name:  "fish",
+			shell: "fish",
+			expectedLines: []string{
+				"# fish completion for openhue",
+				"complete -c openhue",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			root, out := createTestContext("/bin/zsh")
+			root.SetArgs([]string{"completion", tt.shell})
+
+			// Act
+			err := root.Execute()
+
+			// Assert
+			require.NoError(t, err)
+			for _, expectedLine := range tt.expectedLines {
+				assert.Contains(t, out.String(), expectedLine)
+			}
+		})
+	}
+}
+
+func TestCompletionSetupPrintsCommandForDetectedShell(t *testing.T) {
+	tests := []struct {
+		name            string
+		detectedShell   string
+		expectedCommand string
+	}{
+		{
+			name:            "bash",
+			detectedShell:   "/opt/homebrew/bin/bash",
+			expectedCommand: "source <(openhue completion bash)",
+		},
+		{
+			name:            "zsh",
+			detectedShell:   "/bin/zsh",
+			expectedCommand: "source <(openhue completion zsh)",
+		},
+		{
+			name:            "fish",
+			detectedShell:   "/opt/homebrew/bin/fish",
+			expectedCommand: "openhue completion fish | source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			root, out := createTestContext(tt.detectedShell)
+			root.SetArgs([]string{"completion", "setup"})
+
+			// Act
+			err := root.Execute()
+
+			// Assert
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), tt.expectedCommand)
+		})
+	}
+}
+
+func TestCompletionSetupReturnsAnErrorForUnsupportedShell(t *testing.T) {
+	// Arrange
+	root, out := createTestContext("/bin/tcsh")
+	root.SetArgs([]string{"completion", "setup"})
+
+	// Act
+	err := root.Execute()
+
+	// Assert
+	require.Error(t, err)
+	assert.Empty(t, strings.TrimSpace(out.String()))
+	assert.Contains(t, err.Error(), "unsupported shell")
+}
+
+func createTestContext(shell string) (*cobra.Command, *strings.Builder) {
+	out := &strings.Builder{}
+	root := &cobra.Command{Use: "openhue"}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.AddGroup(&cobra.Group{
+		ID:    "config",
+		Title: "Configuration",
+	})
+	root.AddCommand(newCmdCompletion(out, func() string {
+		return shell
+	}))
+
+	return root, out
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	op "github.com/openhue/openhue-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"openhue-cli/cmd/completion"
 	"openhue-cli/cmd/get"
 	"openhue-cli/cmd/mcp"
 	"openhue-cli/cmd/set"
@@ -85,18 +86,23 @@ func Execute(buildInfo *openhue.BuildInfo) {
 	root := NewCmdOpenHue(ctx)
 
 	// add sub commands
-	root.AddCommand(version.NewCmdVersion(ctx))
-	root.AddCommand(setup.NewCmdSetup(ctx.Io))
-	root.AddCommand(setup.NewCmdDiscover(ctx.Io))
-	root.AddCommand(setup.NewCmdConfigure(ctx.Io))
-
-	root.AddCommand(set.NewCmdSet(ctx))
-	root.AddCommand(get.NewCmdGet(ctx))
-	root.AddCommand(mcp.NewCmdMcp(ctx))
+	addCommands(root, ctx)
 
 	// execute the root command
 	err := root.Execute()
 	cobra.CheckErr(err)
+}
+
+func addCommands(root *cobra.Command, ctx *openhue.Context) {
+	root.AddCommand(version.NewCmdVersion(ctx))
+	root.AddCommand(setup.NewCmdSetup(ctx.Io))
+	root.AddCommand(setup.NewCmdDiscover(ctx.Io))
+	root.AddCommand(setup.NewCmdConfigure(ctx.Io))
+	root.AddCommand(completion.NewCmdCompletion(ctx.Io))
+
+	root.AddCommand(set.NewCmdSet(ctx))
+	root.AddCommand(get.NewCmdGet(ctx))
+	root.AddCommand(mcp.NewCmdMcp(ctx))
 }
 
 // containsCmd verifies if the given cobra.Command is contained in the group.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"openhue-cli/openhue"
+)
+
+func TestRootIncludesCompletionSetupCommand(t *testing.T) {
+	// Arrange
+	t.Setenv("SHELL", "/bin/zsh")
+	root, out := createTestContext()
+	root.SetArgs([]string{"completion", "setup"})
+
+	// Act
+	err := root.Execute()
+
+	// Assert
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "source <(openhue completion zsh)")
+}
+
+func createTestContext() (*cobra.Command, *bytes.Buffer) {
+	ctx, out := openhue.NewTestContext(nil)
+	root := NewCmdOpenHue(ctx)
+	addCommands(root, ctx)
+
+	return root, out
+}


### PR DESCRIPTION
This PR adds explicit Cobra completion commands for bash, zsh, and fish, plus a helper command that prints the right setup command based on `$SHELL`.

This PR:
- adds `openhue completion bash`, `openhue completion zsh`, and `openhue completion fish`
- adds `openhue completion setup` so users can run one command to see how to enable completions in their current shell
- wires the command into the root command under Configuration
- adds Homebrew caveats that suggest the matching command during install
- adds tests around completion output, shell detection, unsupported shells, and root wiring

I kept this to generating and sourcing completion scripts. It doesn't write shell config files or change persistent shell startup files for users. Happy to change it to that if that's the direction you'd like to go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell completion support for bash, zsh, and fish. Run `openhue completion setup` to enable completions for your shell.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openhue/openhue-cli/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->